### PR TITLE
feat(firstore-palm-gen-text): better error handling & docs

### DIFF
--- a/firestore-palm-gen-text/POSTINSTALL.md
+++ b/firestore-palm-gen-text/POSTINSTALL.md
@@ -23,6 +23,20 @@ ref.onSnapshot(snap => {
 })
 ```
 
+## About the models
+
+The extension uses the [PaLM API](https://developers.generativeai.google/guide/palm_api_overview) to generate responses. Each of the models supported by the API has its own metadata, please check the [PaLM API documentation](https://developers.generativeai.google/models/language#model) for more information on the capabilities of your chosen model.
+
+## Handling errors
+
+If the extension encounters an error, it will write an error message to the document in `status` field. You can use this field to monitor for errors in your documents.
+
+### Handling `ACCESS_TOKEN_SCOPE_INSUFFICIENT` error
+
+If the error message is `The project or service account likely does not have access to the PaLM API`, please ensure that you have already signed up for the [waitlist](https://makersuite.google.com/waitlist) and have been approved before installing the extension.
+
+Then, you need to add the PaLM API to your project. You can do this by going to the [PaLM API page](https://console.cloud.google.com/apis/library/language.googleapis.com) in the Google Cloud Console and clicking "Enable". 
+
 ## Monitoring
 
 As a best practice, you can [monitor the activity](https://firebase.google.com/docs/extensions/manage-installed-extensions#monitor) of your installed extension, including checks on its health, usage, and logs.

--- a/firestore-palm-gen-text/functions/src/errors.ts
+++ b/firestore-palm-gen-text/functions/src/errors.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {GoogleError} from 'google-gax';
 
 export const missingVariableError = (field: string) =>
   new Error(
@@ -23,3 +24,31 @@ export const variableTypeError = (field: string) =>
   new Error(
     `Error substituting variable "${field}" variables into prompt. All variable fields must be strings.`
   );
+
+interface GoogleErrorWithReason extends GoogleError {
+  reason: string;
+}
+
+function isGoogleErrorWithReason(e: Error): e is GoogleErrorWithReason {
+  return (e as GoogleErrorWithReason).reason !== undefined;
+}
+
+enum GoogleErrorReason {
+  ACCESS_TOKEN_SCOPE_INSUFFICIENT = 'ACCESS_TOKEN_SCOPE_INSUFFICIENT',
+}
+
+export function createErrorMessage(e: unknown): string {
+  if (!(e instanceof Error)) {
+    return 'Unknown Error. Please look to function logs for more details.';
+  }
+
+  if (isGoogleErrorWithReason(e)) {
+    switch (e.reason) {
+      case GoogleErrorReason.ACCESS_TOKEN_SCOPE_INSUFFICIENT:
+        return 'The project or service account likely does not have access to the PaLM API.';
+      default:
+        return `An error occurred while processing the provided message, ${e.message}`;
+    }
+  }
+  return `An error occurred while processing the provided message, ${e.message}`;
+}

--- a/firestore-palm-gen-text/functions/src/index.ts
+++ b/firestore-palm-gen-text/functions/src/index.ts
@@ -20,7 +20,11 @@ import config from './config';
 import {TextGenerator, TextGeneratorRequestOptions} from './generator';
 import {DocumentReference, FieldValue} from 'firebase-admin/firestore';
 import * as Mustache from 'mustache';
-import {missingVariableError, variableTypeError} from './errors';
+import {
+  createErrorMessage,
+  missingVariableError,
+  variableTypeError,
+} from './errors';
 
 const {
   model,
@@ -129,17 +133,13 @@ export const generateText = functions.firestore
           };
       return ref.update(completeData);
     } catch (e: any) {
-      // TODO: this error log needs to be more specific, not necessarily an API error here.
-      // logs.errorCallingGLMAPI(ref.path, e);
+      logs.errorCallingGLMAPI(ref.path, e);
+      const errorMessage = createErrorMessage(e);
       return ref.update({
         'status.state': 'ERRORED',
         'status.completeTime': FieldValue.serverTimestamp(),
         'status.updateTime': FieldValue.serverTimestamp(),
-        'status.error':
-          // TODO: Probably have better errors here but still don't leak underlying error.
-          e.message
-            ? e.message
-            : 'An error occurred while processing the provided text.',
+        'status.error': errorMessage,
       });
     }
   });


### PR DESCRIPTION
This PR adds better error handling by writing the error messages back to Firestore and documenting it in PREINSTALL.
It also documents the model limits, linked to #51