### PR TITLE
fix(firestore-palm-chatbot): skip documents which are missing fields

### DIFF
--- a/firestore-palm-chatbot/functions/src/discussion.ts
+++ b/firestore-palm-chatbot/functions/src/discussion.ts
@@ -19,6 +19,7 @@ import * as logs from './logs';
 import {GoogleAuth} from 'google-auth-library';
 import {APIGenerateMessageRequest, APIMessage, APIExample} from './types';
 export interface Message {
+  path?: string;
   prompt?: string;
   response?: string;
 }
@@ -111,7 +112,6 @@ export interface GenerateMessageResponse {
 }
 
 export class Discussion {
-  private apiKey: string | null = null;
   private client: DiscussServiceClient;
   context?: string;
   examples?: Message[] = [];
@@ -205,8 +205,12 @@ export class Discussion {
   private messagesToApi(messages: Message[]): APIMessage[] {
     const out: APIMessage[] = [];
     for (const message of messages) {
-      if (message.prompt) out.push({author: '0', content: message.prompt});
-      if (message.response) out.push({author: '1', content: message.response});
+      if (!message.prompt || !message.response) {
+        logs.warnMissingPromptOrResponse(message.path!);
+        continue;
+      }
+      out.push({author: '0', content: message.prompt});
+      out.push({author: '1', content: message.response});
     }
     return out;
   }

--- a/firestore-palm-chatbot/functions/src/index.ts
+++ b/firestore-palm-chatbot/functions/src/index.ts
@@ -143,6 +143,7 @@ async function fetchHistory(ref: DocumentReference) {
       snap => snap.get('status') && snap.get('status.state') === 'COMPLETED'
     )
     .map(snap => ({
+      path: snap.ref.path,
       prompt: snap.get(promptField),
       response: snap.get(responseField),
     }));

--- a/firestore-palm-chatbot/functions/src/logs.ts
+++ b/firestore-palm-chatbot/functions/src/logs.ts
@@ -24,6 +24,12 @@ export const init = (config: Config) => {
   );
 };
 
+export const warnMissingPromptOrResponse = (path: string) => {
+  logger.warn(
+    `[firestore-palm-chatbot] Document '${path}' is missing either a prompt or response field, will not be included in history!`
+  );
+};
+
 export const missingField = (field: string, path: string) => {
   logger.info(
     `[firestore-palm-chatbot] Missing ordering field '${field}' on document '${path}', setting to current timestamp.`


### PR DESCRIPTION
If a user deleted a field on a COMPLETED document, this doc would be included and this would result in an "messages must alternate" error from PaLM.

This PR skips messages without the necessary fields, and emits a warning.