### PR TITLE
fix(firestore-semantic-search): delete backfilling bucket if it exists

### DIFF
--- a/firestore-semantic-search/CHANGELOG.md
+++ b/firestore-semantic-search/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fixed CHANGELOG to reflect current state of extension.
 - Fixed an issue with `queryIndex` where it didn't accept a list as documented.
 - Fixed an issue when uninstalling the extension and installing again where it complains about the Firestore metdata collection already existing.
+- Fixed an issue when uninstalling the extension and installing again with a different location.
 
 ## Version 0.1.4
 

--- a/firestore-semantic-search/functions/src/common/utils.ts
+++ b/firestore-semantic-search/functions/src/common/utils.ts
@@ -40,11 +40,9 @@ export async function getEmbeddingsBucket(): Promise<Bucket> {
   } catch (error) {
     // If the bucket doesn't exist, create it with the specified location
     if ((error as any)?.code === 404) {
-      console.log(error);
       const [bucket] = await admin.storage().bucket(bucketName).create({
         location: config.location,
       });
-      console.log(`Bucket ${bucketName} created in the specified location.`);
       return bucket;
     } else {
       // If the error is not related to the bucket's existence, rethrow the error

--- a/firestore-semantic-search/functions/src/functions/backfill_trigger.ts
+++ b/firestore-semantic-search/functions/src/functions/backfill_trigger.ts
@@ -51,7 +51,15 @@ export async function backfillTriggerHandler({
   // This might be a left-over from a previous installation.
   try {
     const bucket = admin.storage().bucket(config.bucketName);
-    await bucket.deleteFiles({prefix: 'datapoints', autoPaginate: false});
+
+    if (await bucket.exists()) {
+      functions.logger.info(
+        `Found an existing bucket ${config.bucketName}, deleting it...`
+      );
+
+      await bucket.deleteFiles({prefix: 'datapoints', autoPaginate: false});
+      await bucket.delete({ignoreNotFound: true});
+    }
   } catch (error) {
     // Ignore the error if the bucket doesn't exist.
     functions.logger.debug(error);


### PR DESCRIPTION
Re-installing an extension instance in a different location complains about an existing bucket in a different location, this PR ensures to delete the bucket it exists.