### PR TITLE
fix(storage-reverse-image-search): metadata & enqueues collection merge

### DIFF
--- a/storage-reverse-image-search/functions/src/functions/backfill_trigger.ts
+++ b/storage-reverse-image-search/functions/src/functions/backfill_trigger.ts
@@ -92,11 +92,15 @@ export async function backfillTriggerHandler({
 
       try {
         // Create a task document to track the progress of the task.
-        writer.set(admin.firestore().doc(`${config.tasksDoc}/enqueues/${id}`), {
-          taskId: id,
-          status: BackfillStatus.PENDING,
-          objects: chunk.map(object => object.name),
-        });
+        writer.set(
+          admin.firestore().doc(`${config.tasksDoc}/enqueues/${id}`),
+          {
+            taskId: id,
+            status: BackfillStatus.PENDING,
+            objects: chunk.map(object => object.name),
+          },
+          {merge: false}
+        );
 
         if (
           counter % config.batchSize === 0 ||

--- a/storage-reverse-image-search/functions/src/functions/create_index_trigger.ts
+++ b/storage-reverse-image-search/functions/src/functions/create_index_trigger.ts
@@ -54,7 +54,7 @@ export async function createIndexTriggerHandler(
         status: IndexStatus.BUILDING,
         operation,
       },
-      {merge: true}
+      {merge: false}
     );
   }
 }


### PR DESCRIPTION
For some reason `storage-reverse-image-search` keeps throwing if there were a collection with the same name from the previous installation even though it's using `set`. 

This PR is explicitly setting `merge` to `false` to overwrite it.