### PR TITLE
feat(firestore-palm-summarize-text): add max output tokens param

### DIFF
--- a/firestore-palm-summarize-text/CHANGELOG.md
+++ b/firestore-palm-summarize-text/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Version 0.1.7
+
+- Improved summarization prompt to reduce hallucinations
+
+- Added parameter for max output tokens on response
+
 ## Version 0.1.6
 
 - Fixed location bug where apiEndpoint was incorrectly entered

--- a/firestore-palm-summarize-text/README.md
+++ b/firestore-palm-summarize-text/README.md
@@ -84,6 +84,8 @@ Additionally, this extension uses the PaLM API, which is currently in public pre
 
 * Target Summary Length: Number of sentences you would like the summary to be.
 
+* Maximum number of tokens: If you have selected the Vertex AI service as your PaLM API provider, this parameter will be used to set the max_tokens parameter in the Vertex API request. It should be an integer in the range [1,1024]. The default value for the extension is 1024.
+
 * Cloud Functions location: Where do you want to deploy the functions created for this extension? For help selecting a location, refer to the [location selection guide](https://firebase.google.com/docs/functions/locations).
 
 

--- a/firestore-palm-summarize-text/extension.yaml
+++ b/firestore-palm-summarize-text/extension.yaml
@@ -2,7 +2,7 @@
 # https://firebase.google.com/docs/extensions/alpha/ref-extension-yaml
 
 name: firestore-palm-summarize-text # Identifier for your extension
-version: 0.1.6 # Follow semver versioning
+version: 0.1.7 # Follow semver versioning
 specVersion: v1beta # Version of the Firebase Extensions specification
 
 # Friendly display name for your extension (~3-5 words)
@@ -153,6 +153,20 @@ params:
     validationErrorMessage:
       Invalid TARGET_SUMMARY_LENGTH, must be an integer between 1 and 10.
     required: false
+    immutable: false
+
+  - param: MAX_OUTPUT_TOKENS
+    label: Maximum number of tokens
+    description: >-
+      If you have selected the Vertex AI service as your PaLM API provider, this
+      parameter will be used to set the max_tokens parameter in the Vertex API
+      request. It should be an integer in the range [1,1024]. The default value
+      for the extension is 1024.
+    type: string
+    validationRegex: ^(102[0-4]|10[01][0-9]|100[0-9]|[1-9][0-9]{0,2})$
+    validationErrorMessage: Please specify an integer in the range [1,1024]
+    required: false
+    default: 1024
     immutable: false
 
   - param: LOCATION

--- a/firestore-palm-summarize-text/functions/src/config.ts
+++ b/firestore-palm-summarize-text/functions/src/config.ts
@@ -25,6 +25,7 @@ export interface Config {
   provider: string;
   model: string;
   apiKey?: string;
+  maxOutputTokens?: number;
 }
 
 function getModel() {
@@ -56,6 +57,9 @@ const config: Config = {
   provider: process.env.PALM_API_PROVIDER || 'vertex',
   model: getModel(),
   apiKey: process.env.API_KEY,
+  maxOutputTokens: process.env.MAX_OUTPUT_TOKENS
+    ? parseInt(process.env.MAX_OUTPUT_TOKENS)
+    : 1024,
 };
 
 export default config;

--- a/firestore-palm-summarize-text/functions/src/generator.ts
+++ b/firestore-palm-summarize-text/functions/src/generator.ts
@@ -51,13 +51,13 @@ export class TextGenerator {
   candidateCount?: number;
   topP?: number;
   topK?: number;
-  maxOutputTokens?: number;
+  maxOutputTokens: number;
 
   constructor(options: TextGeneratorOptions = {}) {
     this.temperature = options.temperature;
     this.topP = options.topP;
     this.topK = options.topK;
-    this.maxOutputTokens = options.maxOutputTokens;
+    this.maxOutputTokens = options.maxOutputTokens || 1024;
     this.candidateCount = options.candidateCount;
     this.instruction = options.instruction;
     if (options.model) this.model = options.model;
@@ -122,6 +122,7 @@ export class TextGenerator {
       const temperature = options.temperature || this.temperature;
       const topP = options.topP || this.topP;
       const topK = options.topK || this.topK;
+      const maxOutputTokens = options.maxOutputTokens || this.maxOutputTokens;
 
       const parameter: Record<string, string | number> = {};
       // We have to set these conditionally or they get nullified and the request fails with a serialization error.
@@ -134,7 +135,7 @@ export class TextGenerator {
       if (topK) {
         parameter.top_k = topK;
       }
-      parameter.maxOutputTokens = 100;
+      parameter.maxOutputTokens = maxOutputTokens;
 
       const parameters = helpers.toValue(parameter);
 

--- a/firestore-palm-summarize-text/functions/src/index.ts
+++ b/firestore-palm-summarize-text/functions/src/index.ts
@@ -25,6 +25,7 @@ const {textField, responseField, collectionName, targetSummaryLength} = config;
 
 const textGenerator = new TextGenerator({
   model: config.model,
+  maxOutputTokens: config.maxOutputTokens,
 });
 
 logs.init(config);


### PR DESCRIPTION
This PR adds a parameter to change the max output tokens for summarize text, and ups the default