### PR TITLE
docs(firestore-palm-gen-text): update threshold params and docs

### DIFF
--- a/firestore-palm-gen-text/CHANGELOG.md
+++ b/firestore-palm-gen-text/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.1.8
+
+- Added parameters for configuring filter thresholds on developers PaLM API
+- Increased Max content length default
 ## Version 0.1.7
 
 - Fixed location bug where apiEndpoint was incorrectly entered

--- a/firestore-palm-gen-text/PREINSTALL.md
+++ b/firestore-palm-gen-text/PREINSTALL.md
@@ -51,6 +51,15 @@ There are currently two different APIs providing access to PaLM large language m
 
 - For more details on the Vertex AI PaLM API, see the [Vertex AI documentation](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/overview)
 
+
+### Harm filter thresholds
+
+PaLM provides content filters in different categories. This extension currently allows the developer to specify thresholds for these categories. Note that
+the filtering is based on the probability that the prompt or response contains the category of content, and not necessarily the severity of the content.
+
+Currently the extension only supports this feature for the Generative AI for developers PaLM Provider.
+
+For more information see the [documentation](https://developers.generativeai.google/guide/safety_setting) for the Generative AI for developers.
 ### Regenerating a response
 
 Changing the state field of a completed document's status from `COMPLETED` to anything else will retrigger the extension for that document.

--- a/firestore-palm-gen-text/PREINSTALL.md
+++ b/firestore-palm-gen-text/PREINSTALL.md
@@ -59,7 +59,8 @@ the filtering is based on the probability that the prompt or response contains t
 
 Currently the extension only supports this feature for the Generative AI for developers PaLM Provider.
 
-For more information see the [documentation](https://developers.generativeai.google/guide/safety_setting) for the Generative AI for developers.
+For more information see the [documentation](https://developers.generativeai.google/guide/safety_setting) for the Generative AI for Developers PaLM API.
+
 ### Regenerating a response
 
 Changing the state field of a completed document's status from `COMPLETED` to anything else will retrigger the extension for that document.

--- a/firestore-palm-gen-text/README.md
+++ b/firestore-palm-gen-text/README.md
@@ -67,7 +67,8 @@ the filtering is based on the probability that the prompt or response contains t
 
 Currently the extension only supports this feature for the Generative AI for developers PaLM Provider.
 
-For more information see the [documentation](https://developers.generativeai.google/guide/safety_setting) for the Generative AI for developers.
+For more information see the [documentation](https://developers.generativeai.google/guide/safety_setting) for the Generative AI for Developers PaLM API.
+
 ### Regenerating a response
 
 Changing the state field of a completed document's status from `COMPLETED` to anything else will retrigger the extension for that document.

--- a/firestore-palm-gen-text/README.md
+++ b/firestore-palm-gen-text/README.md
@@ -59,6 +59,15 @@ There are currently two different APIs providing access to PaLM large language m
 
 - For more details on the Vertex AI PaLM API, see the [Vertex AI documentation](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/overview)
 
+
+### Harm filter thresholds
+
+PaLM provides content filters in different categories. This extension currently allows the developer to specify thresholds for these categories. Note that
+the filtering is based on the probability that the prompt or response contains the category of content, and not necessarily the severity of the content.
+
+Currently the extension only supports this feature for the Generative AI for developers PaLM Provider.
+
+For more information see the [documentation](https://developers.generativeai.google/guide/safety_setting) for the Generative AI for developers.
 ### Regenerating a response
 
 Changing the state field of a completed document's status from `COMPLETED` to anything else will retrigger the extension for that document.
@@ -114,21 +123,21 @@ Additionally, this extension uses the PaLM API, which is currently in public pre
 
 * Candidates field: The field in the message document into which to put the other candidate responses if the candidate count parameter is greater than one. Note this is only available as a feature if you  selected the Generative Language API for Developers as your Palm API provider.
 
-* Maximum number of tokens: If you have selected the Vertex AI service as your PaLM API provider, this parameter will be used to set the max_tokens parameter in the Vertex API request. It should be an integer in the range [1,1024]. The default value for the extension is 100.
+* Maximum number of tokens: If you have selected the Vertex AI service as your PaLM API provider, this parameter will be used to set the max_tokens parameter in the Vertex API request. It should be an integer in the range [1,1024]. The default value for the extension is 1024.
 
-* Derogatory Content Threshold: Threshold for derogatory content. Specify what level of derogatory content is blocked by the PaLM provider. This threshold is applicable only to the Generative Language PaLM API.
+* Derogatory Content Threshold: Threshold for derogatory content. Specify what probability level of derogatory content is blocked by the PaLM provider. This threshold is applicable only to the Generative Language PaLM API.
 
-* Toxicity Threshold: Threshold for toxic content. Specify what level of toxic content is blocked by the PaLM provider. This threshold is applicable only to the Generative Language PaLM API.
+* Toxicity Threshold: Threshold for toxic content. Specify what probability level of toxic content is blocked by the PaLM provider. This threshold is applicable only to the Generative Language PaLM API.
 
-* Sexual Content Threshold: Threshold for sexual content. Specify what level of sexual content is blocked by the PaLM provider. This threshold is applicable only to the Generative Language PaLM API.
+* Sexual Content Threshold: Threshold for sexual content. Specify what probability level of sexual content is blocked by the PaLM provider. This threshold is currently applicable only to the Generative Language PaLM API.
 
-* Violent Content Threshold: Threshold for violent content. Specify what level of violent content is blocked by the PaLM provider. This threshold is applicable only to the Generative Language PaLM API.
+* Violent Content Threshold: Threshold for violent content. Specify what probability of violent content is blocked by the PaLM provider. This threshold is currently applicable only to the Generative Language PaLM API.
 
-* Medical Content Threshold: Threshold for medical content. Specify what level of medical content is blocked by the PaLM provider. This threshold is applicable only to the Generative Language PaLM API.
+* Medical Content Threshold: Threshold for medical content. Specify what probability level of medical content is blocked by the PaLM provider. This threshold is applicable only to the Generative Language PaLM API.
 
-* Dangerous Content Threshold: Threshold for dangerous content. Specify what level of dangerous content is blocked by the PaLM provider. This threshold is applicable only to the Generative Language PaLM API.
+* Dangerous Content Threshold: Threshold for dangerous content. Specify what probability level of dangerous content is blocked by the PaLM provider. This threshold is applicable only to the Generative Language PaLM API.
 
-* Unspecified Harm Threshold: Threshold for non-specific harmful content. Specify what level of non-specific harmful content is blocked by the PaLM provider. This threshold is applicable only to the Generative Language PaLM API.
+* Unspecified Harm Threshold: Threshold for non-specific harmful content. Specify what probability level of non-specific harmful content is blocked by the PaLM provider. This threshold is applicable only to the Generative Language PaLM API.
 
 
 

--- a/firestore-palm-gen-text/extension.yaml
+++ b/firestore-palm-gen-text/extension.yaml
@@ -1,5 +1,5 @@
 name: firestore-palm-gen-text
-version: 0.1.7
+version: 0.1.8
 specVersion: v1beta
 
 displayName: Language Tasks with PaLM API
@@ -272,22 +272,22 @@ params:
       If you have selected the Vertex AI service as your PaLM API provider, this
       parameter will be used to set the max_tokens parameter in the Vertex API
       request. It should be an integer in the range [1,1024]. The default value
-      for the extension is 100.
+      for the extension is 1024.
     type: string
     validationRegex: ^(102[0-4]|10[01][0-9]|100[0-9]|[1-9][0-9]{0,2})$
     validationErrorMessage: Please specify an integer in the range [1,1024]
     required: false
-    default: 100
+    default: 1024
     immutable: false
 
   - param: DEROGATORY_THRESHOLD
     label: Derogatory Content Threshold
     description: >-
-      Threshold for derogatory content. Specify what level of derogatory content is blocked by the PaLM provider.
+      Threshold for derogatory content. Specify what probability level of derogatory content is blocked by the PaLM provider.
       This threshold is applicable only to the Generative Language PaLM API.
     type: select
     options:
-      - label: Harm block threshold unspecified
+      - label: Block none
         value: HARM_BLOCK_THRESHOLD_UNSPECIFIED
       - label: Block low and above
         value: BLOCK_LOW_AND_ABOVE
@@ -302,11 +302,11 @@ params:
   - param: TOXICITY_THRESHOLD
     label: Toxicity Threshold
     description: >-
-      Threshold for toxic content. Specify what level of toxic content is blocked by the PaLM provider.
+      Threshold for toxic content. Specify what probability level of toxic content is blocked by the PaLM provider.
       This threshold is applicable only to the Generative Language PaLM API.
     type: select
     options:
-      - label: Harm block threshold unspecified
+      - label: Block none
         value: HARM_BLOCK_THRESHOLD_UNSPECIFIED
       - label: Block low and above
         value: BLOCK_LOW_AND_ABOVE
@@ -321,11 +321,11 @@ params:
   - param: SEXUAL_THRESHOLD
     label: Sexual Content Threshold
     description: >-
-      Threshold for sexual content. Specify what level of sexual content is blocked by the PaLM provider.
-      This threshold is applicable only to the Generative Language PaLM API.
+      Threshold for sexual content. Specify what probability level of sexual content is blocked by the PaLM provider.
+      This threshold is currently applicable only to the Generative Language PaLM API.
     type: select
     options:
-      - label: Harm block threshold unspecified
+      - label: Block none
         value: HARM_BLOCK_THRESHOLD_UNSPECIFIED
       - label: Block low and above
         value: BLOCK_LOW_AND_ABOVE
@@ -340,11 +340,11 @@ params:
   - param: VIOLENCE_THRESHOLD
     label: Violent Content Threshold
     description: >-
-      Threshold for violent content. Specify what level of violent content is blocked by the PaLM provider.
-      This threshold is applicable only to the Generative Language PaLM API.
+      Threshold for violent content. Specify what probability of violent content is blocked by the PaLM provider.
+      This threshold is currently applicable only to the Generative Language PaLM API.
     type: select
     options:
-      - label: Harm block threshold unspecified
+      - label: Block none
         value: HARM_BLOCK_THRESHOLD_UNSPECIFIED
       - label: Block low and above
         value: BLOCK_LOW_AND_ABOVE
@@ -359,11 +359,11 @@ params:
   - param: MEDICAL_THRESHOLD
     label: Medical Content Threshold
     description: >-
-      Threshold for medical content. Specify what level of medical content is blocked by the PaLM provider.
+      Threshold for medical content. Specify what probability level of medical content is blocked by the PaLM provider.
       This threshold is applicable only to the Generative Language PaLM API.
     type: select
     options:
-      - label: Harm block threshold unspecified
+      - label: Block none
         value: HARM_BLOCK_THRESHOLD_UNSPECIFIED
       - label: Block low and above
         value: BLOCK_LOW_AND_ABOVE
@@ -378,11 +378,11 @@ params:
   - param: DANGEROUS_THRESHOLD
     label: Dangerous Content Threshold 
     description: >-
-      Threshold for dangerous content. Specify what level of dangerous content is blocked by the PaLM provider.
+      Threshold for dangerous content. Specify what probability level of dangerous content is blocked by the PaLM provider.
       This threshold is applicable only to the Generative Language PaLM API.
     type: select
     options:
-      - label: Harm block threshold unspecified
+      - label: Block none
         value: HARM_BLOCK_THRESHOLD_UNSPECIFIED
       - label: Block low and above
         value: BLOCK_LOW_AND_ABOVE
@@ -397,11 +397,11 @@ params:
   - param: UNSPECIFIED_THRESHOLD
     label: Unspecified Harm Threshold
     description: >-
-      Threshold for non-specific harmful content. Specify what level of non-specific harmful content is blocked by the PaLM provider.
+      Threshold for non-specific harmful content. Specify what probability level of non-specific harmful content is blocked by the PaLM provider.
       This threshold is applicable only to the Generative Language PaLM API.
     type: select
     options:
-      - label: Harm block threshold unspecified
+      - label: Block none
         value: HARM_BLOCK_THRESHOLD_UNSPECIFIED
       - label: Block low and above
         value: BLOCK_LOW_AND_ABOVE


### PR DESCRIPTION
This PR updates the description of the new threshold params, adds reference to them in the PREINSTALL, and ups the MAX_CONTENT_LENGTH default to 1024