### PR TITLE
fix(*): fix safety threshold options in PaLM extensions

### DIFF
--- a/firestore-palm-gen-text/extension.yaml
+++ b/firestore-palm-gen-text/extension.yaml
@@ -287,7 +287,7 @@ params:
       This threshold is applicable only to the Generative Language PaLM API.
     type: select
     options:
-      - label: Block none
+      - label: Default
         value: HARM_BLOCK_THRESHOLD_UNSPECIFIED
       - label: Block low and above
         value: BLOCK_LOW_AND_ABOVE
@@ -295,8 +295,10 @@ params:
         value: BLOCK_MEDIUM_AND_ABOVE
       - label: Block only high
         value: BLOCK_ONLY_HIGH
+      - label: Block none
+        value: BLOCK_NONE
     required: false
-    default: BLOCK_ONLY_HIGH
+    default: HARM_BLOCK_THRESHOLD_UNSPECIFIED
     immutable: false
 
   - param: TOXICITY_THRESHOLD
@@ -306,7 +308,7 @@ params:
       This threshold is applicable only to the Generative Language PaLM API.
     type: select
     options:
-      - label: Block none
+      - label: Default
         value: HARM_BLOCK_THRESHOLD_UNSPECIFIED
       - label: Block low and above
         value: BLOCK_LOW_AND_ABOVE
@@ -314,8 +316,10 @@ params:
         value: BLOCK_MEDIUM_AND_ABOVE
       - label: Block only high
         value: BLOCK_ONLY_HIGH
+      - label: Block none
+        value: BLOCK_NONE
     required: false
-    default: BLOCK_ONLY_HIGH
+    default: HARM_BLOCK_THRESHOLD_UNSPECIFIED
     immutable: false
 
   - param: SEXUAL_THRESHOLD
@@ -325,7 +329,7 @@ params:
       This threshold is currently applicable only to the Generative Language PaLM API.
     type: select
     options:
-      - label: Block none
+      - label: Default
         value: HARM_BLOCK_THRESHOLD_UNSPECIFIED
       - label: Block low and above
         value: BLOCK_LOW_AND_ABOVE
@@ -333,8 +337,10 @@ params:
         value: BLOCK_MEDIUM_AND_ABOVE
       - label: Block only high
         value: BLOCK_ONLY_HIGH
+      - label: Block none
+        value: BLOCK_NONE
     required: false
-    default: BLOCK_ONLY_HIGH
+    default: HARM_BLOCK_THRESHOLD_UNSPECIFIED
     immutable: false
 
   - param: VIOLENCE_THRESHOLD
@@ -344,7 +350,7 @@ params:
       This threshold is currently applicable only to the Generative Language PaLM API.
     type: select
     options:
-      - label: Block none
+      - label: Default
         value: HARM_BLOCK_THRESHOLD_UNSPECIFIED
       - label: Block low and above
         value: BLOCK_LOW_AND_ABOVE
@@ -352,8 +358,10 @@ params:
         value: BLOCK_MEDIUM_AND_ABOVE
       - label: Block only high
         value: BLOCK_ONLY_HIGH
+      - label: Block none
+        value: BLOCK_NONE
     required: false
-    default: BLOCK_ONLY_HIGH
+    default: HARM_BLOCK_THRESHOLD_UNSPECIFIED
     immutable: false
 
   - param: MEDICAL_THRESHOLD
@@ -363,7 +371,7 @@ params:
       This threshold is applicable only to the Generative Language PaLM API.
     type: select
     options:
-      - label: Block none
+      - label: Default
         value: HARM_BLOCK_THRESHOLD_UNSPECIFIED
       - label: Block low and above
         value: BLOCK_LOW_AND_ABOVE
@@ -371,8 +379,10 @@ params:
         value: BLOCK_MEDIUM_AND_ABOVE
       - label: Block only high
         value: BLOCK_ONLY_HIGH
+      - label: Block none
+        value: BLOCK_NONE
     required: false
-    default: BLOCK_ONLY_HIGH
+    default: HARM_BLOCK_THRESHOLD_UNSPECIFIED
     immutable: false
 
   - param: DANGEROUS_THRESHOLD
@@ -382,7 +392,7 @@ params:
       This threshold is applicable only to the Generative Language PaLM API.
     type: select
     options:
-      - label: Block none
+      - label: Default
         value: HARM_BLOCK_THRESHOLD_UNSPECIFIED
       - label: Block low and above
         value: BLOCK_LOW_AND_ABOVE
@@ -390,8 +400,10 @@ params:
         value: BLOCK_MEDIUM_AND_ABOVE
       - label: Block only high
         value: BLOCK_ONLY_HIGH
+      - label: Block none
+        value: BLOCK_NONE
     required: false
-    default: BLOCK_ONLY_HIGH
+    default: HARM_BLOCK_THRESHOLD_UNSPECIFIED
     immutable: false
 
   - param: UNSPECIFIED_THRESHOLD
@@ -401,7 +413,7 @@ params:
       This threshold is applicable only to the Generative Language PaLM API.
     type: select
     options:
-      - label: Block none
+      - label: Default
         value: HARM_BLOCK_THRESHOLD_UNSPECIFIED
       - label: Block low and above
         value: BLOCK_LOW_AND_ABOVE
@@ -409,6 +421,8 @@ params:
         value: BLOCK_MEDIUM_AND_ABOVE
       - label: Block only high
         value: BLOCK_ONLY_HIGH
+      - label: Block none
+        value: BLOCK_NONE
     required: false
-    default: BLOCK_ONLY_HIGH
+    default: HARM_BLOCK_THRESHOLD_UNSPECIFIED
     immutable: false

--- a/firestore-palm-summarize-text/extension.yaml
+++ b/firestore-palm-summarize-text/extension.yaml
@@ -176,7 +176,7 @@ params:
       This threshold is applicable only to the Generative Language PaLM API.
     type: select
     options:
-      - label: Block none
+      - label: Default
         value: HARM_BLOCK_THRESHOLD_UNSPECIFIED
       - label: Block low and above
         value: BLOCK_LOW_AND_ABOVE
@@ -184,8 +184,10 @@ params:
         value: BLOCK_MEDIUM_AND_ABOVE
       - label: Block only high
         value: BLOCK_ONLY_HIGH
+      - label: Block none
+        value: BLOCK_NONE
     required: false
-    default: BLOCK_ONLY_HIGH
+    default: HARM_BLOCK_THRESHOLD_UNSPECIFIED
     immutable: false
 
   - param: LOCATION


### PR DESCRIPTION
fixes https://github.com/GoogleCloudPlatform/firebase-extensions/issues/214

Note some content will still be blocked even with BLOCK_NONE set, as there are baseline filters that are not configurable.