### PR TITLE
docs(*): update docs to reflect safety settings

### DIFF
--- a/firestore-palm-chatbot/POSTINSTALL.md
+++ b/firestore-palm-chatbot/POSTINSTALL.md
@@ -31,7 +31,11 @@ ref.onSnapshot(snap => {
 
 ## About the models
 
-The extension uses the [PaLM API](https://developers.generativeai.google/guide/palm_api_overview) to generate responses. Each of the models supported by the API has its own metadata, please check the [PaLM API documentation](https://developers.generativeai.google/models/language#model) for more information on the capabilities of your chosen model.
+The extension gives you a choice of PaLM API provider
+
+- The Vertex AI PaLM API: For more details on the Vertex AI PaLM API, see the [Vertex AI documentation](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/overview)
+
+- The Generative Language for Developers PaLM API [PaLM API](https://developers.generativeai.google/guide/palm_api_overview).
 
 ## Handling errors
 

--- a/firestore-palm-chatbot/PREINSTALL.md
+++ b/firestore-palm-chatbot/PREINSTALL.md
@@ -35,9 +35,10 @@ You can also configure the model to return different results by tweaking model p
 
 There are currently two different APIs providing access to PaLM large language models. The PaLM Developer (Generative Language) API, and Vertex AI. This extension will prompt you to pick an API on installation. For production use-cases we recommend Vertex AI, as the Generative Language API is still in public preview.
 
+- For more details on the Vertex AI PaLM API, see the [Vertex AI documentation](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/overview)
+
 - The PaLM developer (Generative Language) API is currently in public preview, and you will need to sign up [waitlist](https://makersuite.google.com/waitlist) if you want to use it. For details and limitations, see the [PaLM API documentation](https://developers.generativeai.google/guide/preview_faq).
 
-- For more details on the Vertex AI PaLM API, see the [Vertex AI documentation](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/overview)
 
 ### Regenerating a response
 
@@ -50,6 +51,15 @@ If you have not already done so, you will first need to apply for access to the 
 Once you have access, please [enable the Generative Language API in your Google Cloud Project](https://console.cloud.google.com/apis/library/generativelanguage.googleapis.com) before installing this extension.
 
 Ensure you have a [Cloud Firestore database](https://firebase.google.com/docs/firestore/quickstart) set up in your Firebase project, and enabled the Generative Language API in your Google Cloud Project before installing this extension.
+
+## Safety Thresholds
+
+Both the Generative Language for Developers and Vertex AI models have safety thresholds, to block inappropriate content. You can read the details here:
+
+- [Vertex AI responsible AI documentation](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai)
+- [Generative AI for Developers safety settings documentation](https://developers.generativeai.google/guide/safety_setting)
+
+At this moment, only Generative AI for Developers allows configuring safety thresholds via their API, and only for their text generation models, not their chat-bison models.
 
 ## Billing
 

--- a/firestore-palm-chatbot/README.md
+++ b/firestore-palm-chatbot/README.md
@@ -43,9 +43,10 @@ You can also configure the model to return different results by tweaking model p
 
 There are currently two different APIs providing access to PaLM large language models. The PaLM Developer (Generative Language) API, and Vertex AI. This extension will prompt you to pick an API on installation. For production use-cases we recommend Vertex AI, as the Generative Language API is still in public preview.
 
+- For more details on the Vertex AI PaLM API, see the [Vertex AI documentation](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/overview)
+
 - The PaLM developer (Generative Language) API is currently in public preview, and you will need to sign up [waitlist](https://makersuite.google.com/waitlist) if you want to use it. For details and limitations, see the [PaLM API documentation](https://developers.generativeai.google/guide/preview_faq).
 
-- For more details on the Vertex AI PaLM API, see the [Vertex AI documentation](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/overview)
 
 ### Regenerating a response
 
@@ -58,6 +59,15 @@ If you have not already done so, you will first need to apply for access to the 
 Once you have access, please [enable the Generative Language API in your Google Cloud Project](https://console.cloud.google.com/apis/library/generativelanguage.googleapis.com) before installing this extension.
 
 Ensure you have a [Cloud Firestore database](https://firebase.google.com/docs/firestore/quickstart) set up in your Firebase project, and enabled the Generative Language API in your Google Cloud Project before installing this extension.
+
+## Safety Thresholds
+
+Both the Generative Language for Developers and Vertex AI models have safety thresholds, to block inappropriate content. You can read the details here:
+
+- [Vertex AI responsible AI documentation](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai)
+- [Generative AI for Developers safety settings documentation](https://developers.generativeai.google/guide/safety_setting)
+
+At this moment, only Generative AI for Developers allows configuring safety thresholds via their API, and only for their text generation models, not their chat-bison models.
 
 ## Billing
 

--- a/firestore-palm-gen-text/PREINSTALL.md
+++ b/firestore-palm-gen-text/PREINSTALL.md
@@ -52,14 +52,14 @@ There are currently two different APIs providing access to PaLM large language m
 - For more details on the Vertex AI PaLM API, see the [Vertex AI documentation](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/overview)
 
 
-### Harm filter thresholds
+## Safety Thresholds
 
-PaLM provides content filters in different categories. This extension currently allows the developer to specify thresholds for these categories. Note that
-the filtering is based on the probability that the prompt or response contains the category of content, and not necessarily the severity of the content.
+Both the Generative Language for Developers and Vertex AI models have safety thresholds, to block inappropriate content. You can read the details here:
 
-Currently the extension only supports this feature for the Generative AI for developers PaLM Provider.
+- [Vertex AI responsible AI documentation](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai)
+- [Generative AI for Developers safety settings documentation](https://developers.generativeai.google/guide/safety_setting)
 
-For more information see the [documentation](https://developers.generativeai.google/guide/safety_setting) for the Generative AI for Developers PaLM API.
+At this moment, only Generative AI for Developers allows configuring safety thresholds via their API, and only for their text generation models, not their chat-bison models.
 
 ### Regenerating a response
 

--- a/firestore-palm-gen-text/README.md
+++ b/firestore-palm-gen-text/README.md
@@ -60,14 +60,14 @@ There are currently two different APIs providing access to PaLM large language m
 - For more details on the Vertex AI PaLM API, see the [Vertex AI documentation](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/overview)
 
 
-### Harm filter thresholds
+## Safety Thresholds
 
-PaLM provides content filters in different categories. This extension currently allows the developer to specify thresholds for these categories. Note that
-the filtering is based on the probability that the prompt or response contains the category of content, and not necessarily the severity of the content.
+Both the Generative Language for Developers and Vertex AI models have safety thresholds, to block inappropriate content. You can read the details here:
 
-Currently the extension only supports this feature for the Generative AI for developers PaLM Provider.
+- [Vertex AI responsible AI documentation](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai)
+- [Generative AI for Developers safety settings documentation](https://developers.generativeai.google/guide/safety_setting)
 
-For more information see the [documentation](https://developers.generativeai.google/guide/safety_setting) for the Generative AI for Developers PaLM API.
+At this moment, only Generative AI for Developers allows configuring safety thresholds via their API, and only for their text generation models, not their chat-bison models.
 
 ### Regenerating a response
 

--- a/firestore-palm-summarize-text/PREINSTALL.md
+++ b/firestore-palm-summarize-text/PREINSTALL.md
@@ -35,13 +35,14 @@ There are currently two different APIs providing access to PaLM large language m
 
 - For more details on the Vertex AI PaLM API, see the [Vertex AI documentation](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/overview)
 
-### Harm filter thresholds
+## Safety Thresholds
 
-PaLM provides content filters in different categories. For simplicity, this extension allows you to set a global threshold for all categories in one configuration parameter, specified during installation. Note that the filtering is based on the probability that the prompt or response contains the category of content, and not necessarily the severity of the content.
+Both the Generative Language for Developers and Vertex AI models have safety thresholds, to block inappropriate content. You can read the details here:
 
-Currently the extension only supports this feature for the Generative AI for developers PaLM Provider.
+- [Vertex AI responsible AI documentation](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai)
+- [Generative AI for Developers safety settings documentation](https://developers.generativeai.google/guide/safety_setting)
 
-For more information see the [documentation](https://developers.generativeai.google/guide/safety_setting) for the Generative AI for Developers PaLM API.
+At this moment, only Generative AI for Developers allows configuring safety thresholds via their API, and only for their text generation models, not their chat-bison models.
 
 ### Regenerating a response
 

--- a/firestore-palm-summarize-text/README.md
+++ b/firestore-palm-summarize-text/README.md
@@ -43,13 +43,14 @@ There are currently two different APIs providing access to PaLM large language m
 
 - For more details on the Vertex AI PaLM API, see the [Vertex AI documentation](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/overview)
 
-### Harm filter thresholds
+## Safety Thresholds
 
-PaLM provides content filters in different categories. For simplicity, this extension allows you to set a global threshold for all categories in one configuration parameter, specified during installation. Note that the filtering is based on the probability that the prompt or response contains the category of content, and not necessarily the severity of the content.
+Both the Generative Language for Developers and Vertex AI models have safety thresholds, to block inappropriate content. You can read the details here:
 
-Currently the extension only supports this feature for the Generative AI for developers PaLM Provider.
+- [Vertex AI responsible AI documentation](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai)
+- [Generative AI for Developers safety settings documentation](https://developers.generativeai.google/guide/safety_setting)
 
-For more information see the [documentation](https://developers.generativeai.google/guide/safety_setting) for the Generative AI for Developers PaLM API.
+At this moment, only Generative AI for Developers allows configuring safety thresholds via their API, and only for their text generation models, not their chat-bison models.
 
 ### Regenerating a response
 


### PR DESCRIPTION
This PR updates the docs of the PaLM extensions, to mention that the chat models do not support configurable safety thresholds