### PR TITLE
Simplify BACKUP_INSTANCE_ID validationRegex to make it more efficient

### DIFF
--- a/firestore-incremental-capture/extension.yaml
+++ b/firestore-incremental-capture/extension.yaml
@@ -262,7 +262,7 @@ params:
       The name of the Firestore instance to backup the database to.
 
     example: projects/my-project/databases/my-backup
-    validationRegex: '^projects/(.*?)+/databases/(.*?)+$'
+    validationRegex: '^projects\/(.*?)+\/databases\/(.*?)+$'
     validationErrorMessage: Enter a valid instance id
     default: projects/my-project/databases/my-backup/(default)
     required: true

--- a/firestore-incremental-capture/extension.yaml
+++ b/firestore-incremental-capture/extension.yaml
@@ -262,7 +262,7 @@ params:
       The name of the Firestore instance to backup the database to.
 
     example: projects/my-project/databases/my-backup
-    validationRegex: '^projects\/(.*?)+\/databases\/(.*?)+$'
+    validationRegex: '^projects\/.+\/databases\/.+$'
     validationErrorMessage: Enter a valid instance id
     default: projects/my-project/databases/my-backup/(default)
     required: true

--- a/firestore-incremental-capture/extension.yaml
+++ b/firestore-incremental-capture/extension.yaml
@@ -262,7 +262,7 @@ params:
       The name of the Firestore instance to backup the database to.
 
     example: projects/my-project/databases/my-backup
-    validationRegex: '^projects\/.+\/databases\/.+$'
+    validationRegex: '^projects/.+/databases/.+$'
     validationErrorMessage: Enter a valid instance id
     default: projects/my-project/databases/my-backup/(default)
     required: true


### PR DESCRIPTION
`start = Date.now(); 'projects/my-project/databases/my-backup/(default)'.match('^projects/(.*?)+/databases/(.*?)+$'); console.log(Date.now() - start)`

12383ms 

vs
`start = Date.now(); 'projects/my-project/databases/my-backup/(default)'.match('^projects/.+/databases/.+$'); console.log(Date.now() - start)`

0ms