### PR TITLE
fix(text-to-speech): save file path back to firestore document

### DIFF
--- a/text-to-speech/functions/src/index.ts
+++ b/text-to-speech/functions/src/index.ts
@@ -74,6 +74,10 @@ export const textToSpeech = functions.firestore
           const file = bucket.file(fileName);
           await file.save(Buffer.from(speech.audioContent));
 
+          await snap.ref.update({
+            audioPath: `gs://${config.bucketName}/${fileName}`,
+          });
+
           return;
         }
       } catch (error) {


### PR DESCRIPTION
Based on the document on https://extensions.dev/extensions/googlecloud/text-to-speech the audioPath should be saved back to the firestore document

`Writes the path to the Storage object back in the same document.`

This PR should fix it. 