### PR TITLE
chore(*-search): typo in param `ACCELERATOR_TYPE`

### DIFF
--- a/firestore-semantic-search/README.md
+++ b/firestore-semantic-search/README.md
@@ -101,7 +101,7 @@ Additionally, this extension uses the PaLM API, which is currently in public pre
 
 * Machine type: The type of machine that is deployed for the index endpoint. [Read more about machine types config here](https://cloud.google.com/vertex-ai/docs/predictions/configure-compute#g2-series).
 
-* Acceletaor type: The accelerator type for the deployed index endpoint. [Read more about accelerator types config here](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/MachineSpec#AcceleratorType).
+* Accelerator type: The accelerator type for the deployed index endpoint. [Read more about accelerator types config here](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/MachineSpec#AcceleratorType).
 
 * Accelerator Count: The number of accelerators to attach to the the deployed index endpoint machine. [Read more about accelerator counts config here](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/MachineSpec).
 

--- a/firestore-semantic-search/extension.yaml
+++ b/firestore-semantic-search/extension.yaml
@@ -530,7 +530,7 @@ params:
         value: g2-standard-16
 
   - param: ACCELERATOR_TYPE
-    label: Acceletaor type
+    label: Accelerator type
     description: >-
       The accelerator type for the deployed index endpoint. [Read more about
       accelerator types config

--- a/storage-reverse-image-search/README.md
+++ b/storage-reverse-image-search/README.md
@@ -95,7 +95,7 @@ This extension uses other Firebase and Google Cloud Platform services, which hav
 
 * Machine type: The type of machine that is deployed for the index endpoint. [Read more about machine types config here](https://cloud.google.com/vertex-ai/docs/predictions/configure-compute#g2-series).
 
-* Acceletaor type: The accelerator type for the deployed index endpoint. [Read more about accelerator types config here](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/MachineSpec#AcceleratorType).
+* Accelerator type: The accelerator type for the deployed index endpoint. [Read more about accelerator types config here](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/MachineSpec#AcceleratorType).
 
 * Accelerator Count: The number of accelerators to attach to the the deployed index endpoint machine. [Read more about accelerator counts config here](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/MachineSpec).
 

--- a/storage-reverse-image-search/README.md
+++ b/storage-reverse-image-search/README.md
@@ -74,7 +74,7 @@ This extension uses other Firebase and Google Cloud Platform services, which hav
 * Cloud Storage bucket for images: Which Cloud Storage bucket will has images you want to index and search?
 
 
-* The path to images in the bucket: If images is located inside a folder in the bucket, what's the path? If empty the root of the bucket will be used.
+* The path to images in the bucket: If images are located inside a folder in the bucket, what's the path? If empty, the root of the bucket will be used.
 
 
 * Do backfill?: Whether to backfill embeddings for all documents currently in the collection.

--- a/storage-reverse-image-search/README.md
+++ b/storage-reverse-image-search/README.md
@@ -97,7 +97,7 @@ This extension uses other Firebase and Google Cloud Platform services, which hav
 
 * Accelerator type: The accelerator type for the deployed index endpoint. [Read more about accelerator types config here](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/MachineSpec#AcceleratorType).
 
-* Accelerator Count: The number of accelerators to attach to the the deployed index endpoint machine. [Read more about accelerator counts config here](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/MachineSpec).
+* Accelerator Count: The number of accelerators to attach to the deployed index endpoint machine. [Read more about accelerator counts config here](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/MachineSpec).
 
 * Min replica count: The minimum number of machine replicas for the deployed index endpoint. [Read more about min replica counts config here](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/DedicatedResources).
 

--- a/storage-reverse-image-search/extension.yaml
+++ b/storage-reverse-image-search/extension.yaml
@@ -518,7 +518,7 @@ params:
         value: g2-standard-16
 
   - param: ACCELERATOR_TYPE
-    label: Acceletaor type
+    label: Accelerator type
     description: >-
       The accelerator type for the deployed index endpoint. [Read more about
       accelerator types config

--- a/storage-reverse-image-search/extension.yaml
+++ b/storage-reverse-image-search/extension.yaml
@@ -555,7 +555,7 @@ params:
   - param: ACCELERATOR_COUNT
     label: Accelerator Count
     description: >-
-      The number of accelerators to attach to the the deployed index endpoint
+      The number of accelerators to attach to the deployed index endpoint
       machine. [Read more about accelerator counts config
       here](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/MachineSpec).
     default: 1

--- a/storage-reverse-image-search/extension.yaml
+++ b/storage-reverse-image-search/extension.yaml
@@ -208,8 +208,8 @@ params:
   - param: IMG_PATH
     label: The path to images in the bucket
     description: >
-      If images is located inside a folder in the bucket, what's the path? If
-      empty the root of the bucket will be used.
+      If images are located inside a folder in the bucket, what's the path? If
+      empty, the root of the bucket will be used.
     type: string
     example: root/images
     validationRegex: ^[\w-]+(\/[\w-]+)*$


### PR DESCRIPTION
Closes #293 & closes #295 & closes #297