### PR TITLE
ci: increase node version to 18

### DIFF
--- a/.github/workflows/readmes-updated.yaml
+++ b/.github/workflows/readmes-updated.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: 'npm'
           cache-dependency-path: '**/functions/package-lock.json'
 


### PR DESCRIPTION
The generate-readme workflow is failing on version 16. Increase to 18.