### PR TITLE
chore(*-search): fixes a typo `maxiumum`

### DIFF
--- a/firestore-semantic-search/README.md
+++ b/firestore-semantic-search/README.md
@@ -107,7 +107,7 @@ Additionally, this extension uses the PaLM API, which is currently in public pre
 
 * Min replica count: The minimum number of machine replicas for the deployed index endpoint. [Read more about min replica counts config here](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/DedicatedResources).
 
-* Max replica count: The maxiumum number of machine replicas for the deployed index endpoint when the traffic against it increases. [Read more about max replica config here](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/DedicatedResources).
+* Max replica count: The maximum number of machine replicas for the deployed index endpoint when the traffic against it increases. [Read more about max replica config here](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/DedicatedResources).
 
 * Cloud Functions location: Where do you want to deploy the functions created for this extension? For help selecting a location, refer to the [location selection guide](https://firebase.google.com/docs/functions/locations).
 

--- a/firestore-semantic-search/extension.yaml
+++ b/firestore-semantic-search/extension.yaml
@@ -589,7 +589,7 @@ params:
   - param: MAX_REPLICA_COUNT
     label: Max replica count
     description: >-
-      The maxiumum number of machine replicas for the deployed index endpoint
+      The maximum number of machine replicas for the deployed index endpoint
       when the traffic against it increases. [Read more about max replica config
       here](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/DedicatedResources).
     default: 1

--- a/storage-reverse-image-search/README.md
+++ b/storage-reverse-image-search/README.md
@@ -101,7 +101,7 @@ This extension uses other Firebase and Google Cloud Platform services, which hav
 
 * Min replica count: The minimum number of machine replicas for the deployed index endpoint. [Read more about min replica counts config here](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/DedicatedResources).
 
-* Max replica count: The maxiumum number of machine replicas for the deployed index endpoint when the traffic against it increases. [Read more about max replica config here](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/DedicatedResources).
+* Max replica count: The maximum number of machine replicas for the deployed index endpoint when the traffic against it increases. [Read more about max replica config here](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/DedicatedResources).
 
 * Cloud Functions location: Where do you want to deploy the functions created for this extension? For help selecting a location, refer to the [location selection guide](https://firebase.google.com/docs/functions/locations).
 

--- a/storage-reverse-image-search/extension.yaml
+++ b/storage-reverse-image-search/extension.yaml
@@ -579,7 +579,7 @@ params:
   - param: MAX_REPLICA_COUNT
     label: Max replica count
     description: >-
-      The maxiumum number of machine replicas for the deployed index endpoint
+      The maximum number of machine replicas for the deployed index endpoint
       when the traffic against it increases. [Read more about max replica config
       here](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/DedicatedResources).
     default: 1


### PR DESCRIPTION
Closes #296