### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/readmes-updated.yaml
+++ b/.github/workflows/readmes-updated.yaml
@@ -40,7 +40,7 @@ jobs:
         run: |
           mkdir -p ~/.npm-global
           npm config set prefix '~/.npm-global'
-          echo "::set-output name=dir::$(npm config get prefix)"
+          echo "dir=$(npm config get prefix)" >> "$GITHUB_OUTPUT"
 
       - name: Cache global dependencies
         uses: actions/cache@v2


### PR DESCRIPTION
reopening https://github.com/GoogleCloudPlatform/firebase-extensions/pull/342

`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter