### PR TITLE
[firestore-genai-chatbot][FIX] Always getting error 429 - Too Many Requests

### DIFF
--- a/firestore-genai-chatbot/functions/src/index.ts
+++ b/firestore-genai-chatbot/functions/src/index.ts
@@ -38,6 +38,6 @@ const processor = new FirestoreOnWriteProcessor<
 
 export const generateMessage = functions.firestore
   .document(config.collectionName)
-  .onWrite(async change => {
+  .onCreate(async change => {
     return processor.run(change);
   });


### PR DESCRIPTION
## Main change
change: `onWrite` => `onCreate`

## Motivation
in order to avoid redundant calls to the processor, we should trigger it only for new documents, no need to call it on updates or on deletions.