### PR TITLE
fix: update default model name to `gemini-1.0-pro`

### DIFF
--- a/firestore-genai-chatbot/POSTINSTALL.md
+++ b/firestore-genai-chatbot/POSTINSTALL.md
@@ -40,7 +40,7 @@ The extension gives you a choice of what provider to use for the available model
 ## About the models
 
 For Google AI the list of supported models is [here](https://ai.google.dev/models/gemini), and this parameter should be set to the model name, the second segment of the model code (for
-example models/gemini-pro should be chosen as gemini-pro).
+example `models/gemini-1.0-pro` should be chosen as `gemini-1.0-pro`).
 
 For Vertex AI, the list of models is [here](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/models).
 

--- a/firestore-genai-chatbot/extension.yaml
+++ b/firestore-genai-chatbot/extension.yaml
@@ -108,7 +108,7 @@ params:
       [Google AI Gemini models](https://ai.google.dev/models/gemini)
     type: string
     required: true
-    default: gemini-pro
+    default: gemini-1.0-pro
     immutable: false
 
   - param: COLLECTION_NAME

--- a/firestore-multimodal-genai/POSTINSTALL.md
+++ b/firestore-multimodal-genai/POSTINSTALL.md
@@ -34,7 +34,7 @@ The extension gives you a choice of what provider to use for the available model
 ## About the models
 
 For Google AI the list of supported models is [here](https://ai.google.dev/models/gemini), and this parameter should be set to the model name, the second segment of the model code (for
-example models/gemini-pro should be chosen as gemini-pro).
+example `models/gemini-1.0-pro` should be chosen as `gemini-1.0-pro`).
 
 For Vertex AI, the list of models is [here](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/models).
 

--- a/firestore-multimodal-genai/PREINSTALL.md
+++ b/firestore-multimodal-genai/PREINSTALL.md
@@ -60,7 +60,7 @@ In this case, `review_text`` is a field of the Firestore document and will be su
 When installing this extension you will be prompted to pick a Gemini model.
 
 For Google AI the list of supported models is [here](https://ai.google.dev/models/gemini), and this parameter should be set to the model name, the second segment of the model code (for
-example models/gemini-pro should be chosen as gemini-pro).
+example `models/gemini-1.0-pro` should be chosen as `gemini-1.0-pro`).
 
 For Vertex AI, the list of models is [here](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/models).
 

--- a/firestore-multimodal-genai/README.md
+++ b/firestore-multimodal-genai/README.md
@@ -68,7 +68,7 @@ In this case, `review_text`` is a field of the Firestore document and will be su
 When installing this extension you will be prompted to pick a Gemini model.
 
 For Google AI the list of supported models is [here](https://ai.google.dev/models/gemini), and this parameter should be set to the model name, the second segment of the model code (for
-example models/gemini-pro should be chosen as gemini-pro).
+example `models/gemini-1.0-pro` should be chosen as `gemini-1.0-pro`).
 
 For Vertex AI, the list of models is [here](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/models).
 

--- a/firestore-multimodal-genai/extension.yaml
+++ b/firestore-multimodal-genai/extension.yaml
@@ -113,7 +113,7 @@ params:
       [Google AI Gemini models](https://ai.google.dev/models/gemini)
     type: string
     required: true
-    default: gemini-pro
+    default: gemini-1.0-pro
     immutable: false
 
   - param: API_KEY


### PR DESCRIPTION
Resolves #508.

Update the default value to `gemini-1.0-pro` which supports the latest stable version of Gemini 1.0 Pro on both Google AI and Vertex AI.