### PR TITLE
fix(firestore-vector-search): allow array values for prefilter

### DIFF
--- a/firestore-vector-search/functions/src/queries/util.ts
+++ b/firestore-vector-search/functions/src/queries/util.ts
@@ -17,7 +17,7 @@ const operatorSchema = z.enum([
 export const prefilterSchema = z.object({
   field: z.string(),
   operator: operatorSchema,
-  value: z.string(),
+  value: z.union([z.string(), z.array(z.string())]),
 });
 
 export const parseLimit = (limit: unknown) => {


### PR DESCRIPTION
Currently if you try to use the "in" operator with an array value in a prefilter you get an invalid argument error. By updating line 20 like I have, the function now accepts the array.