### PR TITLE
fix(*): singapore location value

### DIFF
--- a/firestore-semantic-search/extension.yaml
+++ b/firestore-semantic-search/extension.yaml
@@ -646,7 +646,7 @@ params:
       - label: Mumbai (asia-south1)
         value: asia-south1
       - label: Singapore (asia-southeast1)
-        value: asia-south1
+        value: asia-southeast1
       - label: Sydney (australia-southeast1)
         value: australia-southeast1
     required: true

--- a/storage-reverse-image-search/extension.yaml
+++ b/storage-reverse-image-search/extension.yaml
@@ -627,7 +627,7 @@ params:
       - label: Mumbai (asia-south1)
         value: asia-south1
       - label: Singapore (asia-southeast1)
-        value: asia-south1
+        value: asia-southeast1
       - label: Sydney (australia-southeast1)
         value: australia-southeast1
     required: true


### PR DESCRIPTION
Fixes #525 in the following extensions:
- firestore-semantic-search
- storage-reverse-image-search