### PR TITLE
fix(firestore-genai-chatbot): fetchHistory should order by asc

### DIFF
--- a/firestore-genai-chatbot/CHANGELOG.md
+++ b/firestore-genai-chatbot/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - chore: bump genkit version
 
+- fix: change sort order for correct default behavior
+
 ## Version 0.0.11
 
 - refactor: use Firebase Genkit SDK to access Gemini API

--- a/firestore-genai-chatbot/functions/src/firestore.ts
+++ b/firestore-genai-chatbot/functions/src/firestore.ts
@@ -8,7 +8,7 @@ import {extractOverrides} from './overrides';
 const {promptField, responseField, orderField} = config;
 
 export async function fetchHistory(ref: DocumentReference) {
-  const collSnap = await ref.parent.orderBy(orderField, 'desc').get();
+  const collSnap = await ref.parent.orderBy(orderField).get();
 
   const refData = await ref.get();
   const refOrderFieldVal = refData.get(orderField);


### PR DESCRIPTION
rebase of https://github.com/GoogleCloudPlatform/firebase-extensions/pull/615

fixes https://github.com/GoogleCloudPlatform/firebase-extensions/issues/504 