### PR TITLE
fix(firestore-vector-search): updates firebase-extension-utilities, as required for recent firebase-functions update to extension

### DIFF
--- a/firestore-vector-search/functions/package.json
+++ b/firestore-vector-search/functions/package.json
@@ -24,7 +24,7 @@
     "@google-cloud/pubsub": "^4.0.7",
     "@google-cloud/vertexai": "^0.1.3",
     "@google/generative-ai": "^0.1.3",
-    "@invertase/firebase-extension-utilities": "^0.1.2",
+    "@invertase/firebase-extension-utilities": "^0.1.3",
     "faiss-node": "^0.5.1",
     "firebase-admin": "^13.4.0",
     "firebase-functions": "^6.3.2",


### PR DESCRIPTION
Fails for now, as firebase-extension-utilities v0.1.3 not released yet.