### PR TITLE
chore(firestore-incremental-capture): run npm audit fix

### DIFF
--- a/firestore-incremental-capture/functions/package-lock.json
+++ b/firestore-incremental-capture/functions/package-lock.json
@@ -6536,9 +6536,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
This PR fixes some small vulnerability fixes in the incremental capture extension

supersedes https://github.com/GoogleCloudPlatform/firebase-extensions/pull/822