### PR TITLE
test(firestore-genai-chatbot): fix flaky tests

### DIFF
--- a/firestore-genai-chatbot/CHANGELOG.md
+++ b/firestore-genai-chatbot/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.0.18
+
+- chore: remove flaky assertions from emulator tests
+
 ## Version 0.0.17
 
 - feat: Add support for Gemini 3 Pro Preview

--- a/firestore-genai-chatbot/extension.yaml
+++ b/firestore-genai-chatbot/extension.yaml
@@ -1,5 +1,5 @@
 name: firestore-genai-chatbot
-version: 0.0.17
+version: 0.0.18
 specVersion: v1beta
 
 icon: icon.png
@@ -78,7 +78,7 @@ resources:
       eventTrigger:
         eventType: providers/cloud.firestore/eventTypes/document.write
         resource: projects/${PROJECT_ID}/databases/(default)/documents/${COLLECTION_NAME}/{messageId}
-      runtime: 'nodejs20'
+      runtime: "nodejs20"
       timeout: 540s
 
 params:
@@ -199,7 +199,7 @@ params:
       extension will listen to the specified collection(s) for new message
       documents.
     type: string
-    validationRegex: '^[^/]+(/[^/]+/[^/]+)*$'
+    validationRegex: "^[^/]+(/[^/]+/[^/]+)*$"
     validationErrorMessage: Must be a valid Cloud Firestore Collection
     default: generate
     required: true

--- a/firestore-genai-chatbot/functions/__tests__/google_ai/index.test.ts
+++ b/firestore-genai-chatbot/functions/__tests__/google_ai/index.test.ts
@@ -289,6 +289,5 @@ const simulateFunctionTriggered =
 
 const expectNoOp = async () => {
   await new Promise(resolve => setTimeout(resolve, 100));
-  expect(firestoreObserver).toHaveBeenCalledTimes(1);
   expect(mockGetModel).toHaveBeenCalledTimes(0);
 };

--- a/firestore-genai-chatbot/functions/__tests__/vertex_ai/index.test.ts
+++ b/firestore-genai-chatbot/functions/__tests__/vertex_ai/index.test.ts
@@ -284,6 +284,5 @@ const simulateFunctionTriggered =
 
 const expectNoOp = async () => {
   await new Promise(resolve => setTimeout(resolve, 100));
-  expect(firestoreObserver).toHaveBeenCalledTimes(1);
   expect(mockGetModel).toHaveBeenCalledTimes(0);
 };


### PR DESCRIPTION
This PR removes assertions on the firebaseObserver from the emulator, which I believe is was a race-condition an not necessary for these no-op cases.

Ran the test suites 100 times to verify:

<img width="390" height="197" alt="Screenshot 2026-01-27 at 16 14 58" src="https://github.com/user-attachments/assets/87c1de76-aa48-4918-af87-1ee83df5cb8b" />
