### PR TITLE
chore: adjust dependabot to only use a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    reviewers:
+      - 'CorieW'
+      - 'cabljac'
+      - 'HassanBahati'
+    labels:
+      - 'dependencies'
+      - 'automated'
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'
+    groups:
+      minor-and-patch:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'


### PR DESCRIPTION
Changes dependabot from making individual dependency bump PRs to [grouping](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--) the bumps into one PR. 

**Example Screenshot**
<img width="1254" height="1323" alt="image" src="https://github.com/user-attachments/assets/d8d4b5d8-f5a6-4d92-ba2b-4e5332f570f8" />
