### PR TITLE
fix(dependabot): ignore major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,6 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
+    ignore:
+      - dependency-name: '*'
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Will no longer create PRs to update to the latest major update.