### PR TITLE
chore(dependabot): remove hardcoded reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,6 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-    reviewers:
-      - 'CorieW'
-      - 'cabljac'
-      - 'HassanBahati'
     labels:
       - 'dependencies'
       - 'automated'


### PR DESCRIPTION
Removes hardcoded reviewers from the `dependabot.yml` file, as this is an [outdated](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/) configuration option.