### PR TITLE
fix(firestore-semantic-search): correct version to 0.1.10

### DIFF
--- a/firestore-semantic-search/CHANGELOG.md
+++ b/firestore-semantic-search/CHANGELOG.md
@@ -1,10 +1,6 @@
-## Version 0.1.11
-
-chore: bump runtime to Node.js 22
-chore: run npm audit fix
-
 ## Version 0.1.10
 
+chore: bump runtime to Node.js 22
 chore: update and audit packages
 
 ## Version 0.1.9

--- a/firestore-semantic-search/extension.yaml
+++ b/firestore-semantic-search/extension.yaml
@@ -1,5 +1,5 @@
 name: firestore-semantic-search
-version: 0.1.11
+version: 0.1.10
 specVersion: v1beta
 
 icon: icon.png


### PR DESCRIPTION
Version was incorrectly bumped to 0.1.11, skipping 0.1.10 which was never published. Squashes the two changelog entries into 0.1.10.