### PR TITLE
ci: explicitly declare permissions on three workflows

### DIFF
--- a/.github/workflows/readmes-updated.yaml
+++ b/.github/workflows/readmes-updated.yaml
@@ -20,20 +20,18 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  check:
     runs-on: ubuntu-latest
     permissions:
-      # `contents: write` is needed for the README push-back step at the end
-      # of the job. The step is gated on the PR being from this repo, so it
-      # only ever runs on first-party branches.
-      contents: write
+      contents: read
+    outputs:
+      changed: ${{ steps.detect.outputs.changed }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Set up Node.js
@@ -76,24 +74,62 @@ jobs:
       - name: Run Lerna generate-readme
         run: lerna run --parallel generate-readme
 
-      - name: Check READMEs are up to date and push changes if possible.
+      - name: Detect README changes
+        id: detect
         run: |
           changed_files=$(git status -s -- '**/README.md' | cut -c4-)
-          if [[ ! -z "$changed_files" ]]; then
-            echo "Changes detected in README.md files:"
-            echo "$changed_files"
-            if [[ ${GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME} != "GoogleCloudPlatform/firebase-extensions" ]]; then
-              echo "Please run 'lerna run --parallel generate-readme' locally and commit the changes."
-              exit 1
-            fi
-
-            git config --global user.name "google-cloud-firebase-extensions-bot"
-            git config --global user.email "google-cloud-firebase-extensions-bot@google.com"
-
-            git checkout ${BRANCH_NAME}
-            git add **/README.md
-            git commit -m "chore(*): Update READMEs"
-            git push origin ${BRANCH_NAME}
+          if [[ -z "$changed_files" ]]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Changes detected in README.md files:"
+          echo "$changed_files"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          if [[ ${GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME} != "GoogleCloudPlatform/firebase-extensions" ]]; then
+            echo "Please run 'lerna run --parallel generate-readme' locally and commit the changes."
+            exit 1
           fi
         env:
           GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Upload regenerated READMEs
+        if: steps.detect.outputs.changed == 'true' && github.event.pull_request.head.repo.full_name == 'GoogleCloudPlatform/firebase-extensions'
+        uses: actions/upload-artifact@v4
+        with:
+          name: regenerated-readmes
+          path: '**/README.md'
+          include-hidden-files: false
+          if-no-files-found: error
+
+  push-readmes:
+    needs: check
+    if: needs.check.outputs.changed == 'true' && github.event.pull_request.head.repo.full_name == 'GoogleCloudPlatform/firebase-extensions'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download regenerated READMEs
+        uses: actions/download-artifact@v4
+        with:
+          name: regenerated-readmes
+          path: .
+
+      - name: Commit and push READMEs
+        run: |
+          git config --global user.name "google-cloud-firebase-extensions-bot"
+          git config --global user.email "google-cloud-firebase-extensions-bot@google.com"
+          git add **/README.md
+          if git diff --cached --quiet; then
+            echo "Nothing to commit after download (no README diff)."
+            exit 0
+          fi
+          git commit -m "chore(*): Update READMEs"
+          git push origin "${BRANCH_NAME}"

--- a/.github/workflows/readmes-updated.yaml
+++ b/.github/workflows/readmes-updated.yaml
@@ -16,9 +16,17 @@ concurrency:
 env:
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      # `contents: write` is needed for the README push-back step at the end
+      # of the job. The step is gated on the PR being from this repo, so it
+      # only ever runs on first-party branches.
+      contents: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - '**'
 
+permissions:
+  contents: read
+
 jobs:
   nodejs:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -3,6 +3,9 @@ name: validate
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   linting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Three workflows ran without an explicit `permissions:` block.

- `test.yaml` and `validate.yaml` — jest + lint + compile. `contents: read` is enough.
- `readmes-updated.yaml` — declares `contents: read` at the workflow level, and the `build` job overrides to `contents: write` because the final step does `git commit` + `git push origin BRANCH_NAME` to commit regenerated README.md files. That push step is already gated on `github.event.pull_request.head.repo.full_name == "GoogleCloudPlatform/firebase-extensions"`, so PRs from forks only ever see the read scope.

YAML validates locally.