### PR TITLE
fix(firestore-genai-chatbot): retry transient gRPC errors on status writes

### DIFF
--- a/firestore-genai-chatbot/CHANGELOG.md
+++ b/firestore-genai-chatbot/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version 0.0.20
+
+- fix: retry transient gRPC errors (CANCELLED/UNAVAILABLE) on status writes
+- test: serialise Firestore listener teardown to fix flaky emulator tests
+
 ## Version 0.0.19
 
 - chore: bump Cloud Functions runtime to Node.js 22

--- a/firestore-genai-chatbot/extension.yaml
+++ b/firestore-genai-chatbot/extension.yaml
@@ -1,6 +1,6 @@
 name: firestore-genai-chatbot
 
-version: 0.0.19
+version: 0.0.20
 
 specVersion: v1beta
 

--- a/firestore-genai-chatbot/functions/__tests__/google_ai/index.test.ts
+++ b/firestore-genai-chatbot/functions/__tests__/google_ai/index.test.ts
@@ -102,12 +102,19 @@ let collectionName: string;
 describe('generateMessage', () => {
   let unsubscribe: (() => void) | undefined;
 
-  // clear firestore
-  beforeEach(async () => {
+  const clearFirestore = async () => {
     await fetch(
       `http://${process.env.FIRESTORE_EMULATOR_HOST}/emulator/v1/projects/demo-gcp/databases/(default)/documents`,
       {method: 'DELETE'}
     );
+  };
+
+  // Wipe before the suite starts so the first test has a clean slate. The
+  // wipe is otherwise performed in afterEach so it never races a live
+  // onSnapshot listener on the shared gRPC channel.
+  beforeAll(clearFirestore);
+
+  beforeEach(async () => {
     jest.clearAllMocks();
     const randomInteger = Math.floor(Math.random() * 1000000);
     collectionName = config.collectionName.replace(
@@ -127,11 +134,17 @@ describe('generateMessage', () => {
         if (snap.docs.length) firestoreObserver(snap);
       });
   });
-  afterEach(() => {
+  afterEach(async () => {
     if (unsubscribe && typeof unsubscribe === 'function') {
       unsubscribe();
     }
     jest.clearAllMocks();
+    // Let the onSnapshot Listen stream close before wiping the database;
+    // wiping while it tears down disturbs the shared gRPC channel. This is a
+    // best-effort settle to cut test noise — the processor's transient-retry
+    // is the authoritative safeguard against the gRPC cancellation.
+    await new Promise(resolve => setTimeout(resolve, 200));
+    await clearFirestore();
   });
 
   test('should not run if the prompt field is not set', async () => {

--- a/firestore-genai-chatbot/functions/__tests__/vertex_ai/index.test.ts
+++ b/firestore-genai-chatbot/functions/__tests__/vertex_ai/index.test.ts
@@ -105,12 +105,19 @@ let collectionName: string;
 describe('generateMessage', () => {
   let unsubscribe: (() => void) | undefined;
 
-  // clear firestore
-  beforeEach(async () => {
+  const clearFirestore = async () => {
     await fetch(
       `http://${process.env.FIRESTORE_EMULATOR_HOST}/emulator/v1/projects/demo-gcp/databases/(default)/documents`,
       {method: 'DELETE'}
     );
+  };
+
+  // Wipe before the suite starts so the first test has a clean slate. The
+  // wipe is otherwise performed in afterEach so it never races a live
+  // onSnapshot listener on the shared gRPC channel.
+  beforeAll(clearFirestore);
+
+  beforeEach(async () => {
     jest.clearAllMocks();
     const randomInteger = Math.floor(Math.random() * 1000000);
     collectionName = config.collectionName.replace(
@@ -130,11 +137,17 @@ describe('generateMessage', () => {
         if (snap.docs.length) firestoreObserver(snap);
       });
   });
-  afterEach(() => {
+  afterEach(async () => {
     if (unsubscribe && typeof unsubscribe === 'function') {
       unsubscribe();
     }
     jest.clearAllMocks();
+    // Let the onSnapshot Listen stream close before wiping the database;
+    // wiping while it tears down disturbs the shared gRPC channel. This is a
+    // best-effort settle to cut test noise — the processor's transient-retry
+    // is the authoritative safeguard against the gRPC cancellation.
+    await new Promise(resolve => setTimeout(resolve, 200));
+    await clearFirestore();
   });
 
   test('should not run if the prompt field is not set', async () => {

--- a/firestore-genai-chatbot/functions/src/firestore-onwrite-processor/index.ts
+++ b/firestore-genai-chatbot/functions/src/firestore-onwrite-processor/index.ts
@@ -18,12 +18,25 @@ import {DocumentSnapshot} from 'firebase-admin/firestore';
  *
  * - 1  CANCELLED   (connection-level cancel; write did not commit)
  * - 14 UNAVAILABLE (channel/transport unavailable; write did not commit)
+ *
+ * gRPC retry semantics: UNAVAILABLE is safe to retry on the same call,
+ * whereas ABORTED requires a higher-level retry and DEADLINE_EXCEEDED leaves
+ * the write outcome ambiguous — hence both are excluded.
+ *
+ * @see https://grpc.io/docs/guides/retry/
+ * @see https://firebase.google.com/docs/firestore/enterprise/understand-error-codes
  */
 const TRANSIENT_GRPC_CODES = new Set<number>([1, 14]);
 
 /**
  * Determines whether an error is a transient gRPC failure that may be retried.
  *
+ * Firestore client errors expose the numeric gRPC status as `error.code`
+ * (e.g. `{code: 1, details: 'Call cancelled', ...}`); CANCELLED is not
+ * classified as transient by google-gax, so it is never retried internally
+ * and must be handled here.
+ *
+ * @see https://github.com/googleapis/nodejs-firestore/issues/2167
  * @param e the caught error
  * @returns true if the error carries a transient gRPC status code
  */

--- a/firestore-genai-chatbot/functions/src/firestore-onwrite-processor/index.ts
+++ b/firestore-genai-chatbot/functions/src/firestore-onwrite-processor/index.ts
@@ -9,6 +9,57 @@ import {
 } from './common';
 import {DocumentSnapshot} from 'firebase-admin/firestore';
 
+/**
+ * gRPC status codes for transient, connection-level failures that are safe to
+ * retry for idempotent writes. Deliberately narrow: codes that may indicate
+ * the write actually committed (4 DEADLINE_EXCEEDED) or a contention abort
+ * that a blind retry would not resolve (10 ABORTED) are excluded to avoid
+ * ambiguous double-writes.
+ *
+ * - 1  CANCELLED   (connection-level cancel; write did not commit)
+ * - 14 UNAVAILABLE (channel/transport unavailable; write did not commit)
+ */
+const TRANSIENT_GRPC_CODES = new Set<number>([1, 14]);
+
+/**
+ * Determines whether an error is a transient gRPC failure that may be retried.
+ *
+ * @param e the caught error
+ * @returns true if the error carries a transient gRPC status code
+ */
+const isTransientGrpcError = (e: unknown): boolean => {
+  if (typeof e !== 'object' || e === null) return false;
+  const code = (e as {code?: unknown}).code;
+  return typeof code === 'number' && TRANSIENT_GRPC_CODES.has(code);
+};
+
+/**
+ * Runs an operation, retrying with exponential backoff on transient gRPC
+ * errors. The status writes performed by this processor are idempotent, so it
+ * is safe to retry them rather than dropping the document's status when the
+ * Firestore client reports a transient, connection-level failure (e.g. gRPC
+ * `1 CANCELLED` / `14 UNAVAILABLE`).
+ *
+ * @param op the operation to run
+ * @returns the resolved value of the operation
+ */
+const withTransientRetry = async <T>(op: () => Promise<T>): Promise<T> => {
+  const maxAttempts = 4;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await op();
+    } catch (e) {
+      if (attempt >= maxAttempts || !isTransientGrpcError(e)) throw e;
+      // Exponential backoff with full jitter to avoid synchronised retry
+      // spikes when many function instances fail at once.
+      const backoff = 100 * 2 ** (attempt - 1);
+      await new Promise(resolve =>
+        setTimeout(resolve, Math.random() * backoff)
+      );
+    }
+  }
+};
+
 export class FirestoreOnWriteProcessor<
   TInput,
   TOutput extends Record<string, FirestoreField>,
@@ -73,7 +124,7 @@ export class FirestoreOnWriteProcessor<
       ? {[this.statusField]: status}
       : {[this.orderField]: createTime, [this.statusField]: status};
 
-    await change.after.ref.update(update);
+    await withTransientRetry(() => change.after.ref.update(update));
   }
 
   private async writeCompletionEvent(change: Change, output: TOutput) {
@@ -81,25 +132,29 @@ export class FirestoreOnWriteProcessor<
     const stateField = `${this.statusField}.state`;
     const updateTimeField = `${this.statusField}.updateTime`;
     const completeTimeField = `${this.statusField}.completeTime`;
-    await change.after.ref.update({
-      ...output,
-      [stateField]: State.COMPLETED,
-      [updateTimeField]: updateTime,
-      [completeTimeField]: updateTime,
-    });
+    await withTransientRetry(() =>
+      change.after.ref.update({
+        ...output,
+        [stateField]: State.COMPLETED,
+        [updateTimeField]: updateTime,
+        [completeTimeField]: updateTime,
+      })
+    );
   }
 
   private async writeErrorEvent(change: Change, e: unknown) {
     const eventTimestamp = now();
 
     const errorMessage = this.errorFn(e);
-    await change.after.ref.update({
-      [this.statusField]: {
-        state: State.ERROR,
-        updateTime: eventTimestamp,
-        error: errorMessage,
-      },
-    });
+    await withTransientRetry(() =>
+      change.after.ref.update({
+        [this.statusField]: {
+          state: State.ERROR,
+          updateTime: eventTimestamp,
+          error: errorMessage,
+        },
+      })
+    );
   }
 
   async run(change: Change): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes the flaky `firestore-genai-chatbot` emulator test reported in #810.

#832 fixed a *different* flake (a no-op `firestoreObserver` assertion race). A second, lower-rate (~1%) flake remained: `firestore-onwrite-processor` status writes intermittently fail with gRPC `1 CANCELLED: call already cancelled` when the shared firebase-admin gRPC channel is disturbed by the test's `onSnapshot` Listen stream racing the `beforeEach` REST database wipe.

## Changes

- **Prod hardening:** wrap the idempotent status writes (`writeStartEvent` / `writeCompletionEvent` / `writeErrorEvent`) in a bounded retry (`withTransientRetry`). Retry set is deliberately narrow — only non-committing transient codes `1 CANCELLED` and `14 UNAVAILABLE` (4 `DEADLINE_EXCEEDED` / 10 `ABORTED` excluded to avoid ambiguous double-writes). Jittered exponential backoff, max 4 attempts.
- **Test hardening:** serialise Firestore listener teardown — DB wipe moved out of `beforeEach` into `afterEach` (after `unsubscribe()` + settle), with a `beforeAll` initial wipe. Applied to both `google_ai` and `vertex_ai` suites. This is defense-in-depth; the prod retry is the authoritative safeguard.
- Version bump to `0.0.20` (CHANGELOG + extension.yaml).

## Verification

| | Failures |
|---|---|
| Pre-fix | 1 / 100 (~1%) |
| Post-fix | 0 / 100 |
| Post-review-fix | 0 / 30 |

Changes additionally reviewed by two independent fresh-context passes; the retry code set was narrowed and jitter added as a result.

Closes #810