### PR TITLE
ci: build tfjs-node native addon for firestore-semantic-search and storage-reverse-image-search

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,15 +59,18 @@ jobs:
 
       # Dependencies are installed with --ignore-scripts, which skips the
       # @tensorflow/tfjs-node postinstall that fetches its native addon. Build
-      # the addon from source so firestore-semantic-search test suites that
-      # require('@tensorflow/tfjs-node') can load.
-      - name: Build firestore-semantic-search native addon (tfjs-node)
+      # the addon from source so test suites that require('@tensorflow/tfjs-node')
+      # can load (firestore-semantic-search and storage-reverse-image-search).
+      - name: Build tfjs-node native addons
         uses: nick-invision/retry@v1
         with:
-          timeout_minutes: 15
+          timeout_minutes: 20
           retry_wait_seconds: 30
           max_attempts: 3
-          command: cd firestore-semantic-search/functions && npm rebuild @tensorflow/tfjs-node --build-addon-from-source
+          command: |
+            for ext in firestore-semantic-search storage-reverse-image-search; do
+              (cd "$ext/functions" && npm rebuild @tensorflow/tfjs-node --build-addon-from-source)
+            done
 
       - name: Build emulator functions
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,6 +57,18 @@ jobs:
       - name: Bootstrap monorepo dependencies
         run: npx lerna bootstrap --no-ci --ignore-scripts
 
+      # Dependencies are installed with --ignore-scripts, which skips the
+      # @tensorflow/tfjs-node postinstall that fetches its native addon. Build
+      # the addon from source so firestore-semantic-search test suites that
+      # require('@tensorflow/tfjs-node') can load.
+      - name: Build firestore-semantic-search native addon (tfjs-node)
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 15
+          retry_wait_seconds: 30
+          max_attempts: 3
+          command: cd firestore-semantic-search/functions && npm rebuild @tensorflow/tfjs-node --build-addon-from-source
+
       - name: Build emulator functions
         run: |
           cd _emulator/functions


### PR DESCRIPTION
## Problem

The Testing workflow is **red on every PR** (e.g. observed on #1059). `firestore-semantic-search:test` fails to even load 5 suites:

```
The Node.js native addon module (tfjs_binding.node) can not be found at path:
  .../@tensorflow/tfjs-node/lib/napi-v8/tfjs_binding.node
> 17 | require('@tensorflow/tfjs-node');
```

## Root cause

`.github/workflows/test.yaml` installs dependencies with `npm ci --ignore-scripts` and `lerna bootstrap --ignore-scripts`. `--ignore-scripts` skips the `@tensorflow/tfjs-node` postinstall, which is what fetches/builds its native addon (`tfjs_binding.node`) and libtensorflow. Every `firestore-semantic-search` suite that `require('@tensorflow/tfjs-node')` then throws at module load, failing `lerna run test` and the whole workflow. (Earlier green runs were riding a warm `node_modules` cache that still held the addon.)

This is unrelated to the historically `xtest`-disabled flaky tests in that extension and unrelated to the genai-chatbot flake fix.

## Fix

Add a retried CI step after bootstrap that rebuilds the addon from source for `firestore-semantic-search/functions`:

```yaml
npm rebuild @tensorflow/tfjs-node --build-addon-from-source
```

Building from source (rather than relying on prebuilt binaries that may not cover the CI Node version) is the robust option and is retried 3× to tolerate transient libtensorflow download failures.