### PR TITLE
docs: clarify semantic search App Check behavior

### DIFF
--- a/firestore-semantic-search/CHANGELOG.md
+++ b/firestore-semantic-search/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.1.11
+
+docs - clarify that the `queryIndex` callable function does not enforce App Check.
+
 ## Version 0.1.10
 
 chore: bump runtime to Node.js 22

--- a/firestore-semantic-search/POSTINSTALL.md
+++ b/firestore-semantic-search/POSTINSTALL.md
@@ -64,7 +64,7 @@ The response contains** only document IDs**, not the full data, since the extens
 
 ## Example client integration
 
-Now that you have an index with data in it, you can run text similarity search queries directly from your client application. Note that this Callable Function is protected by App Check and requires that you are signed in with a [Firebase Auth](https://firebase.google.com/docs/auth) call the Function from your client application.
+Now that you have an index with data in it, you can run text similarity search queries directly from your client application. Note that this Callable Function does not enforce App Check.
 
 ```js
 import firebase from "firebase";

--- a/firestore-semantic-search/PREINSTALL.md
+++ b/firestore-semantic-search/PREINSTALL.md
@@ -8,7 +8,7 @@ Once installed, the extension does the following:
 2. Provides a secure API endpoint to query similar documents (given an input document) that can be used by client applications
 3. (Optional) Backfills existing data from target collection(s)
 
-The query API endpoint is deployed as a Firebase Callable Function, and requires that you are signed in with a Firebase Auth user to successfully call the Function from your client application.
+The query API endpoint is deployed as a Firebase Callable Function. This extension does not enforce App Check for this function.
 
 ### Embeddings models
 

--- a/firestore-semantic-search/README.md
+++ b/firestore-semantic-search/README.md
@@ -16,7 +16,7 @@ Once installed, the extension does the following:
 2. Provides a secure API endpoint to query similar documents (given an input document) that can be used by client applications
 3. (Optional) Backfills existing data from target collection(s)
 
-The query API endpoint is deployed as a Firebase Callable Function, and requires that you are signed in with a Firebase Auth user to successfully call the Function from your client application.
+The query API endpoint is deployed as a Firebase Callable Function. This extension does not enforce App Check for this function.
 
 ### Embeddings models
 

--- a/firestore-semantic-search/extension.yaml
+++ b/firestore-semantic-search/extension.yaml
@@ -1,5 +1,5 @@
 name: firestore-semantic-search
-version: 0.1.10
+version: 0.1.11
 specVersion: v1beta
 
 icon: icon.png


### PR DESCRIPTION
## Summary

Clarifies the firestore-semantic-search docs to state that the `queryIndex` callable does not enforce App Check, then regenerates the README and bumps the extension version/changelog.

Fixes #686

## Checks

- `npm run generate-readme`
- `git diff --check`
