### PR TITLE
fix(speech-to-text): correct output storage path

### DIFF
--- a/speech-to-text/functions/__tests__/util.test.ts
+++ b/speech-to-text/functions/__tests__/util.test.ts
@@ -1,0 +1,27 @@
+import {getTranscodedStoragePath} from '../src/util';
+
+describe('getTranscodedStoragePath', () => {
+  it('uses the file basename when no output path is configured', () => {
+    expect(getTranscodedStoragePath('myDirectory/audio.wav')).toBe(
+      'audio.wav.wav'
+    );
+  });
+
+  it('writes nested input files under the configured output path once', () => {
+    expect(
+      getTranscodedStoragePath('myDirectory/audio.wav', 'transcriptions')
+    ).toBe('transcriptions/audio.wav.wav');
+  });
+
+  it('normalizes leading and trailing slashes in the configured output path', () => {
+    expect(
+      getTranscodedStoragePath('nested/audio.wav', '/transcriptions/')
+    ).toBe('transcriptions/audio.wav.wav');
+  });
+
+  it('does not duplicate the source directory when output path matches it', () => {
+    expect(
+      getTranscodedStoragePath('myDirectory/audio.wav', 'myDirectory')
+    ).toBe('myDirectory/audio.wav.wav');
+  });
+});

--- a/speech-to-text/functions/src/index.ts
+++ b/speech-to-text/functions/src/index.ts
@@ -24,7 +24,12 @@ import * as mkdirp from 'mkdirp';
 import {FieldValue} from 'firebase-admin/firestore';
 
 import * as logs from './logs';
-import {publishFailureEvent, errorFromAny, publishCompleteEvent} from './util';
+import {
+  publishFailureEvent,
+  errorFromAny,
+  publishCompleteEvent,
+  getTranscodedStoragePath,
+} from './util';
 import {
   transcodeToLinear16,
   transcribeAndUpload,
@@ -126,11 +131,14 @@ export const transcribeAudio = functions.storage
         message: 'Transcoding audio file.',
       });
 
+      const transcodedStoragePath = getTranscodedStoragePath(
+        filePath,
+        config.outputStoragePath
+      );
+
       const transcodedUploadResult = await uploadTranscodedFile({
         localPath: transcodeResult.outputPath,
-        storagePath: config.outputStoragePath
-          ? `${config.outputStoragePath}${transcodeResult.outputPath}`
-          : transcodeResult.outputPath.slice(1),
+        storagePath: transcodedStoragePath,
         bucket: bucket,
       });
 

--- a/speech-to-text/functions/src/util.ts
+++ b/speech-to-text/functions/src/util.ts
@@ -15,6 +15,7 @@
  */
 import * as util from 'util';
 import * as ffmpeg from 'fluent-ffmpeg';
+import * as path from 'path';
 import {Failure, TranscribeAudioSuccess} from './types';
 import {Channel} from 'firebase-admin/eventarc';
 import {google} from '@google-cloud/speech/build/protos/protos';
@@ -88,6 +89,18 @@ function separateByTags(
 export const probePromise = util.promisify<string, ffmpeg.FfprobeData>(
   ffmpeg.ffprobe
 );
+
+export function getTranscodedStoragePath(
+  objectName: string,
+  outputStoragePath?: string
+): string {
+  const fileName = `${path.posix.basename(objectName)}.wav`;
+  const normalizedOutputPath = outputStoragePath?.replace(/^\/+|\/+$/g, '');
+
+  return normalizedOutputPath
+    ? `${normalizedOutputPath}/${fileName}`
+    : fileName;
+}
 
 export async function publishFailureEvent(
   eventChannel: Channel,


### PR DESCRIPTION
## Summary

Fixes https://github.com/GoogleCloudPlatform/firebase-extensions/issues/754

- derive the transcoded upload destination from the source object name instead of the local tmp path
- normalize `OUTPUT_STORAGE_PATH` before constructing the destination key
- add regression tests covering nested input paths and matching output prefixes

## Testing
```bash
npm test -- --runInBand util.test.ts
```
```bash
npm run build
```

## Manual verification
- deployed the extension and uploaded `myDirectory/test-audio.m4a`
- verified outputs were created under `OUTPUT_STORAGE_PATH/` without nested source folders or tmp path leakage