### PR TITLE
fix: allow periods in storage path validation regex

### DIFF
--- a/storage-label-videos/CHANGELOG.md
+++ b/storage-label-videos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.1.7
+
+fix: allow periods in storage path validation for INPUT_VIDEOS_PATH and OUTPUT_PATH parameters
+
 ## Version 0.1.6
 
 chore: bump runtime to Node.js 22

--- a/storage-label-videos/extension.yaml
+++ b/storage-label-videos/extension.yaml
@@ -1,5 +1,5 @@
 name: storage-label-videos
-version: 0.1.6
+version: 0.1.7
 specVersion: v1beta
 
 displayName: Label Videos with Cloud Video AI

--- a/storage-label-videos/extension.yaml
+++ b/storage-label-videos/extension.yaml
@@ -108,7 +108,7 @@ params:
       videos from.
     type: string
     example: /video_annotation_input/
-    validationRegex: ^\/([0-9a-zA-Z_\/\-]*\/){0,1}$
+    validationRegex: ^\/([0-9a-zA-Z_.\-\/]*\/){0,1}$
     validationErrorMessage: Invalid storage folder name
     default: /video_annotation_input/
     required: true
@@ -120,7 +120,7 @@ params:
       stored.
     type: string
     example: /video_annotation_output/
-    validationRegex: ^\/([0-9a-zA-Z_\/\-]*\/){0,1}$
+    validationRegex: ^\/([0-9a-zA-Z_.\-\/]*\/){0,1}$
     validationErrorMessage: Invalid storage folder name
     default: /video_annotation_output/
     required: true

--- a/storage-reverse-image-search/CHANGELOG.md
+++ b/storage-reverse-image-search/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.1.12
+
+fix: allow periods in storage path validation for IMG_PATH parameter
+
 ## Version 0.1.11
 
 chore: bump runtime to Node.js 22

--- a/storage-reverse-image-search/extension.yaml
+++ b/storage-reverse-image-search/extension.yaml
@@ -212,7 +212,7 @@ params:
       empty, the root of the bucket will be used.
     type: string
     example: root/images
-    validationRegex: ^[\w-]+(\/[\w-]+)*$
+    validationRegex: ^[\w.-]+(\/[\w.-]+)*$
     validationErrorMessage: Invalid path
     immutable: true
 

--- a/storage-reverse-image-search/extension.yaml
+++ b/storage-reverse-image-search/extension.yaml
@@ -1,5 +1,5 @@
 name: storage-reverse-image-search
-version: 0.1.11
+version: 0.1.12
 specVersion: v1beta
 
 icon: icon.png

--- a/storage-transcode-videos/CHANGELOG.md
+++ b/storage-transcode-videos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.0.6
+
+fix: allow periods in storage path validation for INPUT_VIDEOS_PATH and OUTPUT_VIDEOS_PATH parameters
+
 ## Version 0.0.5
 
 chore: bump runtime to Node.js 22

--- a/storage-transcode-videos/extension.yaml
+++ b/storage-transcode-videos/extension.yaml
@@ -1,5 +1,5 @@
 name: storage-transcode-videos
-version: 0.0.5
+version: 0.0.6
 specVersion: v1beta
 
 displayName: Transcode Videos on Google Cloud Storage

--- a/storage-transcode-videos/extension.yaml
+++ b/storage-transcode-videos/extension.yaml
@@ -87,7 +87,7 @@ params:
       videos from.
     type: string
     example: /video_transcoding_input/
-    validationRegex: ^\/([0-9a-zA-Z_\/\-]*\/){0,1}$
+    validationRegex: ^\/([0-9a-zA-Z_.\-\/]*\/){0,1}$
     validationErrorMessage: Invalid storage folder name
     default: /video_transcoding_input/
     required: true
@@ -99,7 +99,7 @@ params:
       be output to.
     type: string
     example: /video_transcoding_output/
-    validationRegex: ^\/([0-9a-zA-Z_\/\-]*\/){0,1}$
+    validationRegex: ^\/([0-9a-zA-Z_.\-\/]*\/){0,1}$
     validationErrorMessage: Invalid storage folder name
     default: /video_transcoding_output/
     required: true
@@ -109,7 +109,7 @@ params:
     description: >
       A template id for populating a job configuration.
     example: preset/web-hd
-    validationRegex: ^[a-zA-Z0-9\/\-_]+$
+    validationRegex: ^[a-zA-Z0-9\/\-_.]+$
     validationErrorMessage:
       Must be an alphanumeric string. Dashes, underscores and forward slashes
       are also allowed


### PR DESCRIPTION
## Summary

Updated path validation regex to allow periods in storage paths for the following extensions:
- storage-reverse-image-search
- storage-transcode-videos  
- storage-label-videos

## Changes

Changed regex patterns from [\w-] to [\w.-] to permit periods while still validating path structure.

This resolves issues where users could not configure extensions with valid Cloud Storage paths containing periods (e.g., `images.v2/`, `user.uploads/`, `archive.2024/`).

Resolves #667