### PR TITLE
docs(firestore-incremental-capture): document Cloud Tasks max document size limit

### DIFF
--- a/firestore-incremental-capture/CHANGELOG.md
+++ b/firestore-incremental-capture/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.0.13
+
+docs: document the Cloud Tasks maximum document size limitation that causes "Task size too large" errors
+
 ## Version 0.0.12
 
 chore: complete runtime migration to Node.js 22

--- a/firestore-incremental-capture/PREINSTALL.md
+++ b/firestore-incremental-capture/PREINSTALL.md
@@ -12,6 +12,26 @@ The extension also provides a Dataflow connector that can incrementally restore 
 
 This extension is subject to [BigQuery write throughput limitations and availability limitations](https://cloud.google.com/bigquery/quotas), as well as [Cloud Functions at-least-once delivery guarantee](https://cloud.google.com/functions/docs/concepts/execution-environment). Since data is mirrored into BigQuery through Cloud Events, it is recommended to restore to timestamp prior to the current time to prevent missing data.
 
+## Known limitations
+
+### Maximum document size (`Error: Task size too large`)
+
+On every Firestore write, this extension enqueues a [Cloud Task](https://cloud.google.com/tasks) that carries both the previous (`before`) and new (`after`) state of the changed document so the change can be written to BigQuery. Cloud Tasks enforces a [maximum task size of 100KB](https://cloud.google.com/tasks/docs/quotas). Because a single task includes both document states plus serialization overhead, writes to large documents can exceed this limit.
+
+When the limit is exceeded, the change fails to enqueue and the extension logs:
+
+```
+Error: Task size too large
+```
+
+That specific change is **not** captured to BigQuery and therefore cannot be restored. Firestore permits documents up to 1 MiB, which is far larger than the 100KB Cloud Tasks limit, and because both the `before` and `after` states are sent together, a document only needs to be roughly half the limit (~50KB) for an update to fail. This is a limitation of the underlying Cloud Tasks transport and cannot currently be worked around by configuration.
+
+To avoid losing changes:
+
+- Keep documents in the captured collection(s) well below the Cloud Tasks size limit (as a guideline, under ~50KB each).
+- Split large documents into several smaller documents, or move large fields (for example, binary blobs or large arrays) into [Cloud Storage](https://firebase.google.com/docs/storage) and store only a reference in Firestore.
+- If you need to back up documents that exceed this size, consider [Firestore's native Point in Time Recovery](https://firebase.google.com/docs/firestore/use-pitr) and [Scheduled Backups](https://cloud.google.com/firestore/docs/backups) instead, which are not subject to this per-document limit.
+
 ## Additional Setup
 
 Before this extension can run restoration jobs from BigQuery to Firestore, you’ll need to:

--- a/firestore-incremental-capture/README.md
+++ b/firestore-incremental-capture/README.md
@@ -20,6 +20,26 @@ The extension also provides a Dataflow connector that can incrementally restore 
 
 This extension is subject to [BigQuery write throughput limitations and availability limitations](https://cloud.google.com/bigquery/quotas), as well as [Cloud Functions at-least-once delivery guarantee](https://cloud.google.com/functions/docs/concepts/execution-environment). Since data is mirrored into BigQuery through Cloud Events, it is recommended to restore to timestamp prior to the current time to prevent missing data.
 
+## Known limitations
+
+### Maximum document size (`Error: Task size too large`)
+
+On every Firestore write, this extension enqueues a [Cloud Task](https://cloud.google.com/tasks) that carries both the previous (`before`) and new (`after`) state of the changed document so the change can be written to BigQuery. Cloud Tasks enforces a [maximum task size of 100KB](https://cloud.google.com/tasks/docs/quotas). Because a single task includes both document states plus serialization overhead, writes to large documents can exceed this limit.
+
+When the limit is exceeded, the change fails to enqueue and the extension logs:
+
+```
+Error: Task size too large
+```
+
+That specific change is **not** captured to BigQuery and therefore cannot be restored. Firestore permits documents up to 1 MiB, which is far larger than the 100KB Cloud Tasks limit, and because both the `before` and `after` states are sent together, a document only needs to be roughly half the limit (~50KB) for an update to fail. This is a limitation of the underlying Cloud Tasks transport and cannot currently be worked around by configuration.
+
+To avoid losing changes:
+
+- Keep documents in the captured collection(s) well below the Cloud Tasks size limit (as a guideline, under ~50KB each).
+- Split large documents into several smaller documents, or move large fields (for example, binary blobs or large arrays) into [Cloud Storage](https://firebase.google.com/docs/storage) and store only a reference in Firestore.
+- If you need to back up documents that exceed this size, consider [Firestore's native Point in Time Recovery](https://firebase.google.com/docs/firestore/use-pitr) and [Scheduled Backups](https://cloud.google.com/firestore/docs/backups) instead, which are not subject to this per-document limit.
+
 ## Additional Setup
 
 Before this extension can run restoration jobs from BigQuery to Firestore, you’ll need to:

--- a/firestore-incremental-capture/extension.yaml
+++ b/firestore-incremental-capture/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-incremental-capture
-version: 0.0.12
+version: 0.0.13
 specVersion: v1beta
 
 icon: icon.png


### PR DESCRIPTION
## Summary

Fixes the confusion reported in #607, where writes to the extension's captured collection fail with `Error: Task size too large`.

The extension syncs every Firestore write by enqueueing a Cloud Task that carries **both** the `before` and `after` state of the changed document. Cloud Tasks enforces a maximum task size of 100KB, so writes to large documents (Firestore allows up to 1 MiB) exceed the limit, fail to enqueue, and are silently not captured to BigQuery. This is a known limitation of the Cloud Tasks transport rather than a bug, so this PR documents it clearly.

## Changes

- Add a **Known limitations** section to `PREINSTALL.md` and `README.md` explaining:
  - why the `Error: Task size too large` error happens (both document states plus overhead in a single 100KB task),
  - that the affected change is not captured/restorable,
  - practical guidance: keep documents small (~50KB), split large documents, offload large fields to Cloud Storage, or use native PITR / Scheduled Backups for larger documents.
- Bump extension version to `0.0.13` and update `CHANGELOG.md`.

Docs only - no behavior change.

Closes #607
