### PR TITLE
docs(firestore-semantic-search): correct App Check and Auth claims for query function

### DIFF
--- a/firestore-semantic-search/CHANGELOG.md
+++ b/firestore-semantic-search/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.1.11
+
+docs: correct the query function App Check and Firebase Auth claims (the Callable Function does not enforce either by default)
+
 ## Version 0.1.10
 
 chore: bump runtime to Node.js 22

--- a/firestore-semantic-search/POSTINSTALL.md
+++ b/firestore-semantic-search/POSTINSTALL.md
@@ -64,7 +64,7 @@ The response contains** only document IDs**, not the full data, since the extens
 
 ## Example client integration
 
-Now that you have an index with data in it, you can run text similarity search queries directly from your client application. Note that this Callable Function is protected by App Check and requires that you are signed in with a [Firebase Auth](https://firebase.google.com/docs/auth) call the Function from your client application.
+Now that you have an index with data in it, you can run text similarity search queries directly from your client application. Note that this Callable Function does not enforce [App Check](https://firebase.google.com/docs/app-check) or [Firebase Auth](https://firebase.google.com/docs/auth) by default, so any client with your Firebase project configuration is able to call it. The function only ever returns document IDs (never document contents), so your Firestore Security Rules continue to govern access to the underlying documents. If you need to restrict access to the query function itself, enable App Check enforcement and/or add your own authentication checks.
 
 ```js
 import firebase from "firebase";

--- a/firestore-semantic-search/PREINSTALL.md
+++ b/firestore-semantic-search/PREINSTALL.md
@@ -8,7 +8,7 @@ Once installed, the extension does the following:
 2. Provides a secure API endpoint to query similar documents (given an input document) that can be used by client applications
 3. (Optional) Backfills existing data from target collection(s)
 
-The query API endpoint is deployed as a Firebase Callable Function, and requires that you are signed in with a Firebase Auth user to successfully call the Function from your client application.
+The query API endpoint is deployed as a Firebase Callable Function. Note that this function does not enforce Firebase Authentication or [App Check](https://firebase.google.com/docs/app-check) by default, so any client with your Firebase project configuration is able to call it. The function only ever returns document IDs (never document contents), so your Firestore Security Rules continue to govern access to the underlying documents. If you want to restrict who can call the query function itself, enable App Check enforcement and/or add your own authentication checks after installing the extension.
 
 ### Embeddings models
 

--- a/firestore-semantic-search/README.md
+++ b/firestore-semantic-search/README.md
@@ -16,7 +16,7 @@ Once installed, the extension does the following:
 2. Provides a secure API endpoint to query similar documents (given an input document) that can be used by client applications
 3. (Optional) Backfills existing data from target collection(s)
 
-The query API endpoint is deployed as a Firebase Callable Function, and requires that you are signed in with a Firebase Auth user to successfully call the Function from your client application.
+The query API endpoint is deployed as a Firebase Callable Function. Note that this function does not enforce Firebase Authentication or [App Check](https://firebase.google.com/docs/app-check) by default, so any client with your Firebase project configuration is able to call it. The function only ever returns document IDs (never document contents), so your Firestore Security Rules continue to govern access to the underlying documents. If you want to restrict who can call the query function itself, enable App Check enforcement and/or add your own authentication checks after installing the extension.
 
 ### Embeddings models
 

--- a/firestore-semantic-search/extension.yaml
+++ b/firestore-semantic-search/extension.yaml
@@ -1,5 +1,5 @@
 name: firestore-semantic-search
-version: 0.1.10
+version: 0.1.11
 specVersion: v1beta
 
 icon: icon.png


### PR DESCRIPTION
## Summary

Fixes #686.

The `firestore-semantic-search` docs claimed the query Callable Function was "protected by App Check" and "requires that you are signed in with a Firebase Auth user". Neither is true:

- `queryIndex` is registered as a plain `functions.https.onCall(queryIndexHandler)` with no App Check enforcement (`enforceAppCheck` / `runWith`).
- `queryIndexHandler(data)` never inspects the auth context, so no Firebase Auth is required either.

This corrects the documentation to describe the actual behaviour rather than changing the function itself.

## Changes

- `PREINSTALL.md` / `README.md`: replace the "requires a signed-in Firebase Auth user" claim with an accurate description - the function does not enforce Auth or App Check by default, only ever returns document IDs (so Firestore Security Rules still protect document contents), and developers who want to lock down the endpoint should enable App Check enforcement and/or add their own auth checks.
- `POSTINSTALL.md`: same correction to the "Example client integration" note.
- Bumped extension version to `0.1.11` and added a CHANGELOG entry.

## Notes

Scope is documentation only. Adding actual App Check / Auth enforcement to the callable would be a behavioural change and is left for a separate discussion. The related `firestore-vector-search` extension makes no App Check claim in its docs, so no correction was needed there.
