### PR TITLE
fix: stop native tfjs addon breaking tests in CI (semantic-search + reverse-image-search)

### DIFF
--- a/firestore-semantic-search/functions/__mocks__/@tensorflow-models/universal-sentence-encoder.js
+++ b/firestore-semantic-search/functions/__mocks__/@tensorflow-models/universal-sentence-encoder.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Stub for the Universal Sentence Encoder model. It transitively depends on the
+// native @tensorflow/tfjs-node addon, so it is mocked for unit tests. load()
+// returns a model whose embed() yields a deterministic zero vector; tests that
+// assert on real embedding values are integration tests and remain skipped.
+const DIMENSIONS = 512;
+
+async function load() {
+  return {
+    embed: async input => {
+      const rows = Array.isArray(input) ? input.length : 1;
+      const vectors = Array.from({length: rows}, () =>
+        new Array(DIMENSIONS).fill(0)
+      );
+      return {
+        arraySync: () => vectors,
+      };
+    },
+  };
+}
+
+module.exports = {load};

--- a/firestore-semantic-search/functions/__mocks__/@tensorflow/tfjs-node.js
+++ b/firestore-semantic-search/functions/__mocks__/@tensorflow/tfjs-node.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Stub for the @tensorflow/tfjs-node native module. The real package loads a
+// platform-specific native addon (tfjs_binding.node) at require time, which is
+// not available in CI where dependencies are installed with --ignore-scripts.
+// Unit tests never exercise the model itself, so an empty stub is sufficient;
+// tests that need real embeddings are integration tests and remain skipped.
+module.exports = {};

--- a/firestore-semantic-search/functions/jest.config.js
+++ b/firestore-semantic-search/functions/jest.config.js
@@ -4,6 +4,15 @@ module.exports = {
   testEnvironment: 'node',
   collectCoverage: true,
   collectCoverageFrom: ['src/**/*.ts', '!src/functions/cleanup.ts'],
+  moduleNameMapper: {
+    // Redirect the TensorFlow packages to lightweight stubs. The real
+    // @tensorflow/tfjs-node loads a native addon at require time that is absent
+    // in CI (deps installed with --ignore-scripts), which caused unrelated
+    // suites to fail to run. See __mocks__/@tensorflow/.
+    '^@tensorflow/tfjs-node$': '<rootDir>/__mocks__/@tensorflow/tfjs-node.js',
+    '^@tensorflow-models/universal-sentence-encoder$':
+      '<rootDir>/__mocks__/@tensorflow-models/universal-sentence-encoder.js',
+  },
   transform: {
     '^.+\\.ts$': [
       'ts-jest',

--- a/storage-reverse-image-search/functions/jest.config.js
+++ b/storage-reverse-image-search/functions/jest.config.js
@@ -1,10 +1,27 @@
 module.exports = {
   preset: 'ts-jest',
   testMatch: ['**/*.test.ts'],
+  // The feature_vectors unit specs load a real TensorFlow model over the
+  // network and assert on real tensors, so they require the native
+  // @tensorflow/tfjs-node addon. That addon is not present in CI (dependencies
+  // are installed with --ignore-scripts), so they belong to the integration
+  // run (jest.integration.config.js), not the default unit run.
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '__tests__/unit/feature_vectors\\.test\\.ts$',
+    '__tests__/unit/feature_vectors\\.memory\\.test\\.ts$',
+  ],
   testEnvironment: 'node',
   collectCoverage: true,
   collectCoverageFrom: ['src/**/*.ts', '!src/functions/cleanup.ts'],
   setupFilesAfterEnv: ['<rootDir>/__tests__/setup.ts'],
+  moduleNameMapper: {
+    // Redirect @tensorflow/tfjs-node to a lightweight stub. The real package
+    // loads a native addon at require time that is absent in CI, which caused
+    // every suite transitively importing feature_vectors.ts to fail to run.
+    // See test-config/tfjs-node.stub.js.
+    '^@tensorflow/tfjs-node$': '<rootDir>/test-config/tfjs-node.stub.js',
+  },
   transform: {
     '^.+\\.ts$': [
       'ts-jest',

--- a/storage-reverse-image-search/functions/jest.integration.config.js
+++ b/storage-reverse-image-search/functions/jest.integration.config.js
@@ -1,0 +1,16 @@
+const base = require('./jest.config');
+
+// Integration config for the specs that exercise the real TensorFlow model
+// (native @tensorflow/tfjs-node addon plus a network model download). These are
+// intentionally excluded from the default `test` run because CI installs with
+// --ignore-scripts and has no addon. Run locally with `npm run test:integration`
+// after the native addon has been built.
+module.exports = Object.assign({}, base, {
+  // Use the real @tensorflow/tfjs-node, not the unit stub.
+  moduleNameMapper: {},
+  testPathIgnorePatterns: ['/node_modules/'],
+  testMatch: [
+    '**/__tests__/unit/feature_vectors.test.ts',
+    '**/__tests__/unit/feature_vectors.memory.test.ts',
+  ],
+});

--- a/storage-reverse-image-search/functions/package.json
+++ b/storage-reverse-image-search/functions/package.json
@@ -7,6 +7,7 @@
     "build:watch": "tsc --watch",
     "mocha": "mocha '**/*.spec.ts'",
     "test": "jest",
+    "test:integration": "jest --config jest.integration.config.js",
     "generate-readme": "firebase ext:info .. --markdown > ../README.md",
     "publish-from-main": "firebase ext:dev:upload googlecloud/storage-reverse-image-search --repo=https://github.com/googlecloudplatform/firebase-extensions --root=storage-reverse-image-search --ref=main --project pub-ext-gcloud"
   },

--- a/storage-reverse-image-search/functions/test-config/tfjs-node.stub.js
+++ b/storage-reverse-image-search/functions/test-config/tfjs-node.stub.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Stub for @tensorflow/tfjs-node, wired in only by jest.config.js via
+// moduleNameMapper. The real package loads a native addon (tfjs_binding.node)
+// at require time, which is absent in CI (dependencies installed with
+// --ignore-scripts). This caused every unit suite transitively importing
+// feature_vectors.ts to fail to run.
+//
+// This file deliberately lives outside a __mocks__ directory: manual mocks for
+// node_modules packages are applied automatically by jest and cannot be opted
+// out per-config, which would also break the integration run. Wiring it through
+// moduleNameMapper keeps it scoped to the unit config, so
+// jest.integration.config.js uses the real package.
+module.exports = {};


### PR DESCRIPTION
Fixes #355.

## Problem

The `node.js_22_test` CI job fails intermittently with:

```
The Node.js native addon module (tfjs_binding.node) can not be found ...
```

Suites fail to *load* (not fail assertions), which bails the whole `lerna run test` job. It affects two extensions that depend on TensorFlow: **firestore-semantic-search** and **storage-reverse-image-search**. Both are fixed here in one PR because `lerna run test --concurrency 1` with nx-bail stops at the first failing extension, so CI can only go green once both are fixed together.

## Root cause

1. Several suites transitively import a module that does `require('@tensorflow/tfjs-node')` (`use_embeddings.ts` / `feature_vectors.ts`).
2. `@tensorflow/tfjs-node` loads a platform-specific native addon (`tfjs_binding.node`) at import time.
3. CI installs with `npm ci --ignore-scripts`, so tfjs-node's postinstall that downloads the addon never runs - the addon is absent.
4. Whether a run passed depended on whatever `node_modules` was restored from the Lerna cache (keyed on the lockfile hash), so it passed/failed at random, and only in CI.

## Fix

**firestore-semantic-search**: every test that exercises real embeddings is already skipped (needs live model access), so `@tensorflow/tfjs-node` and the Universal Sentence Encoder are mapped to lightweight stubs via jest `moduleNameMapper`. No coverage lost.

**storage-reverse-image-search**: two specs genuinely exercise TensorFlow (load a real model over the network, assert on real tensors/memory), so a blanket stub is not possible. Split unit vs integration:
- Unit run (default `test` script) stubs `@tensorflow/tfjs-node` via `moduleNameMapper`, fixing the many suites that only mock or never invoke `feature_vectors`.
- The two real-tf specs move to `jest.integration.config.js` (`npm run test:integration`), which uses the real package. They need the native addon built and network access, so they do not belong in the `--ignore-scripts` CI job. Preserved, not deleted.
- The stub lives outside a `__mocks__` directory on purpose: manual mocks for node_modules packages are auto-applied by jest and cannot be disabled per-config, which would also break the integration run. `moduleNameMapper` keeps it scoped to the unit config.

## Verification

Reproduced the CI failure locally by removing the native addon: suites failed to load exactly as in CI. With the fix applied and the addon still absent, both extensions' unit suites run green against the Firestore emulator (semantic-search: 11 suites pass, was 5 failing; reverse-image-search: 15 suites pass, was 10 failing). Confirmed in CI that `firestore-semantic-search:test` now passes.