### PR TITLE
fix(firestore-incremental-capture): pin the restoration jar to a release

### DIFF
--- a/.github/workflows/guard-incremental-capture-pin.yaml
+++ b/.github/workflows/guard-incremental-capture-pin.yaml
@@ -1,0 +1,33 @@
+# The install script pins the restoration jar to a release digest. A published
+# version carrying the placeholder would ship a script that refuses to install,
+# so the placeholder must not survive into main.
+name: Guard incremental capture pin
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  digest-pinned:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+
+      - name: Fail if the pipeline digest is still a placeholder
+        env:
+          SCRIPT: firestore-incremental-capture/install/functions/download_restore_firestore.sh
+        run: |
+          set -euo pipefail
+          if grep -q 'REPLACE_WITH_RELEASE_DIGEST' "$SCRIPT"; then
+            echo "::error file=${SCRIPT}::PIPELINE_SHA256 is still a placeholder."
+            echo "Cut the pipeline release named by PIPELINE_RELEASE, then set"
+            echo "PIPELINE_SHA256 to the sha256 of its restore-firestore.jar asset."
+            exit 1
+          fi
+          echo "Pipeline digest is pinned."

--- a/firestore-incremental-capture/CHANGELOG.md
+++ b/firestore-incremental-capture/CHANGELOG.md
@@ -1,3 +1,22 @@
+## Version 0.0.13
+
+fix: download the restoration pipeline from a pinned release instead of the main branch
+
+The install script fetched the Dataflow jar from `raw/main`, so every install
+resolved to whatever build sat at that path at the time it ran. It now downloads
+a release pinned to this extension version and verifies its SHA-256.
+
+Existing installations are unaffected until they upgrade: the jar previously
+served from `main` is frozen and still resolves for older versions. Upgrading is
+recommended - the pinned build is the tested one, and the frozen jar targets an
+Apache Beam SDK that Dataflow deprecated in October 2024.
+
+fix: stop the download step aborting the rest of the setup script
+
+`run.sh` sources this step, so its fallback `exit 0` ended the whole run and
+skipped PITR, Firestore, Artifact Registry, service account and template setup
+while reporting success.
+
 ## Version 0.0.12
 
 chore: complete runtime migration to Node.js 22

--- a/firestore-incremental-capture/POSTINSTALL.md
+++ b/firestore-incremental-capture/POSTINSTALL.md
@@ -77,7 +77,7 @@ gcloud auth configure-docker ${param:LOCATION}-docker.pkg.dev
     --role=roles/artifactregistry.writer
    ```
 
-7. Download the JAR file for the Dataflow Flex Template from the [pinned pipeline release](https://github.com/GoogleCloudPlatform/firebase-extensions/releases/tag/firestore-incremental-capture-pipeline-v1.0.0). Each extension version pins one release; verify the download against the `restore-firestore.jar.sha256` published alongside it.
+7. Download the JAR file for the Dataflow Flex Template from the [pinned pipeline release](https://github.com/GoogleCloudPlatform/firebase-extensions/releases/tag/firestore-incremental-capture-pipeline-v0.1.0). Each extension version pins one release; verify the download against the `restore-firestore.jar.sha256` published alongside it.
 8. Run the following command to build the Dataflow Flex Template. Note that Cloud Storage buckets provisioned after September 30th 2024 are suffixed by `.firebasestorage.app` rather than `.appspot.com` and you should change the following command accordingly:
 
 ```bash

--- a/firestore-incremental-capture/POSTINSTALL.md
+++ b/firestore-incremental-capture/POSTINSTALL.md
@@ -77,7 +77,7 @@ gcloud auth configure-docker ${param:LOCATION}-docker.pkg.dev
     --role=roles/artifactregistry.writer
    ```
 
-7. Download the JAR file for the Dataflow Flex Template [here](https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/firestore-incremental-capture-pipeline/target/restore-firestore.jar).
+7. Download the JAR file for the Dataflow Flex Template from the [pinned pipeline release](https://github.com/GoogleCloudPlatform/firebase-extensions/releases/tag/firestore-incremental-capture-pipeline-v1.0.0). Each extension version pins one release; verify the download against the `restore-firestore.jar.sha256` published alongside it.
 8. Run the following command to build the Dataflow Flex Template. Note that Cloud Storage buckets provisioned after September 30th 2024 are suffixed by `.firebasestorage.app` rather than `.appspot.com` and you should change the following command accordingly:
 
 ```bash

--- a/firestore-incremental-capture/PREINSTALL.md
+++ b/firestore-incremental-capture/PREINSTALL.md
@@ -32,6 +32,24 @@ Before this extension can run restoration jobs from BigQuery to Firestore, youâ€
 
 Further instructions are provided upon installation.
 
+### Upgrading from a version before 0.0.13
+
+Versions before 0.0.13 downloaded the restoration pipeline from the `main`
+branch of this repository, so an install resolved to whichever build sat there
+at the time. From 0.0.13 the download is pinned to a specific pipeline release
+and verified against a checksum recorded in the extension version.
+
+The build those earlier versions resolve to is frozen and keeps working, so
+nothing breaks if you stay put. Upgrading is still recommended: the pinned
+build is the one tested against this version, and the frozen build targets an
+Apache Beam SDK that Dataflow deprecated in October 2024 and may eventually
+decommission, at which point restoration jobs on old versions would stop
+launching.
+
+Upgrading does not change captured data or the BigQuery changelog. Re-run the
+setup script after upgrading so the Dataflow Flex Template is rebuilt from the
+pinned jar.
+
 ### Billing
 
 To install an extension, your project must be on the Blaze (pay as you go) plan. You will be charged a small amount (typically around $0.01/month) for the Firebase resources required by this extension (even if it is not used).

--- a/firestore-incremental-capture/README.md
+++ b/firestore-incremental-capture/README.md
@@ -40,6 +40,24 @@ Before this extension can run restoration jobs from BigQuery to Firestore, youâ€
 
 Further instructions are provided upon installation.
 
+### Upgrading from a version before 0.0.13
+
+Versions before 0.0.13 downloaded the restoration pipeline from the `main`
+branch of this repository, so an install resolved to whichever build sat there
+at the time. From 0.0.13 the download is pinned to a specific pipeline release
+and verified against a checksum recorded in the extension version.
+
+The build those earlier versions resolve to is frozen and keeps working, so
+nothing breaks if you stay put. Upgrading is still recommended: the pinned
+build is the one tested against this version, and the frozen build targets an
+Apache Beam SDK that Dataflow deprecated in October 2024 and may eventually
+decommission, at which point restoration jobs on old versions would stop
+launching.
+
+Upgrading does not change captured data or the BigQuery changelog. Re-run the
+setup script after upgrading so the Dataflow Flex Template is rebuilt from the
+pinned jar.
+
 ### Billing
 
 To install an extension, your project must be on the Blaze (pay as you go) plan. You will be charged a small amount (typically around $0.01/month) for the Firebase resources required by this extension (even if it is not used).

--- a/firestore-incremental-capture/extension.yaml
+++ b/firestore-incremental-capture/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-incremental-capture
-version: 0.0.12
+version: 0.0.13
 specVersion: v1beta
 
 icon: icon.png

--- a/firestore-incremental-capture/install/functions/download_restore_firestore.sh
+++ b/firestore-incremental-capture/install/functions/download_restore_firestore.sh
@@ -1,6 +1,6 @@
-# Pinned to a release tag, never to a branch. Installed versions of this
-# extension run their own copy of this script at install time, so a moving URL
-# would hand an old install a pipeline build it was never tested against.
+# Pinned to a release tag, never to a branch. POSTINSTALL of every published
+# extension version links users to this script on main, so a moving URL would
+# hand an old install a pipeline build it was never tested against.
 # Bump PIPELINE_RELEASE and PIPELINE_SHA256 together, in the same extension
 # version bump that ships the new pipeline.
 PIPELINE_RELEASE="firestore-incremental-capture-pipeline-v1.0.0"
@@ -10,9 +10,13 @@ PIPELINE_URL="https://github.com/GoogleCloudPlatform/firebase-extensions/release
 
 echo -e "${YELLOW}Downloading the JAR file (${PIPELINE_RELEASE})...${NC}"
 
+# Deleting the jar on every failure is what makes this fail closed: run.sh
+# keeps sourcing the remaining steps, and a leftover download would let the
+# Flex Template build stage an unverified pipeline before the failure surfaces.
 download_failed() {
   echo -e "${RED}$1${NC}"
   FAILED_TASKS+=("${RED}${CROSS} Failed to download assets.")
+  rm -f restore-firestore.jar
 }
 
 # This file is sourced by run.sh, so it must return rather than exit - an exit
@@ -23,7 +27,6 @@ elif [ "$PIPELINE_SHA256" = "REPLACE_WITH_RELEASE_DIGEST" ]; then
   download_failed "No pinned checksum is configured for ${PIPELINE_RELEASE}; refusing to use the download."
 elif ! echo "${PIPELINE_SHA256}  restore-firestore.jar" | shasum -a 256 -c - >/dev/null 2>&1; then
   download_failed "Checksum mismatch: ${PIPELINE_URL} does not match the digest pinned in this extension version."
-  rm -f restore-firestore.jar
 else
   echo -e "${GREEN}JAR file downloaded and verified.${NC}"
   SUCCESS_TASKS+=("${GREEN}${TICK} Successfully downloaded assets.")

--- a/firestore-incremental-capture/install/functions/download_restore_firestore.sh
+++ b/firestore-incremental-capture/install/functions/download_restore_firestore.sh
@@ -3,7 +3,7 @@
 # hand an old install a pipeline build it was never tested against.
 # Bump PIPELINE_RELEASE and PIPELINE_SHA256 together, in the same extension
 # version bump that ships the new pipeline.
-PIPELINE_RELEASE="firestore-incremental-capture-pipeline-v1.0.0"
+PIPELINE_RELEASE="firestore-incremental-capture-pipeline-v0.1.0"
 PIPELINE_SHA256="REPLACE_WITH_RELEASE_DIGEST"
 
 PIPELINE_URL="https://github.com/GoogleCloudPlatform/firebase-extensions/releases/download/${PIPELINE_RELEASE}/restore-firestore.jar"

--- a/firestore-incremental-capture/install/functions/download_restore_firestore.sh
+++ b/firestore-incremental-capture/install/functions/download_restore_firestore.sh
@@ -1,42 +1,30 @@
-echo -e "${YELLOW}Downloading the JAR file...${NC}"
+# Pinned to a release tag, never to a branch. Installed versions of this
+# extension run their own copy of this script at install time, so a moving URL
+# would hand an old install a pipeline build it was never tested against.
+# Bump PIPELINE_RELEASE and PIPELINE_SHA256 together, in the same extension
+# version bump that ships the new pipeline.
+PIPELINE_RELEASE="firestore-incremental-capture-pipeline-v1.0.0"
+PIPELINE_SHA256="REPLACE_WITH_RELEASE_DIGEST"
 
-# Use the correct URL
-if curl -L -o restore-firestore.jar "https://github.com/GoogleCloudPlatform/firebase-extensions/raw/main/firestore-incremental-capture-pipeline/target/restore-firestore.jar"; then
-  # Check if the file is actually a JAR and not HTML
-  if file restore-firestore.jar | grep -q "HTML"; then
-    echo -e "${YELLOW}The downloaded file appears to be an HTML page, not a JAR file. The file may not exist at that location.${NC}"
-    
-    # Try alternative sources
-    echo -e "${YELLOW}Trying alternative locations...${NC}"
-    
-    # Alternative 1: Try Firebase Extensions GitHub repo directly
-    if curl -L -o restore-firestore.jar "https://github.com/firebase/extensions/raw/main/firestore-incremental-capture-pipeline/target/restore-firestore.jar"; then
-      if ! file restore-firestore.jar | grep -q "HTML"; then
-        echo -e "${GREEN}JAR file downloaded successfully from alternative location.${NC}"
-        SUCCESS_TASKS+=("${GREEN}${TICK} Successfully downloaded assets.")
-        exit 0
-      fi
-    fi
-    
-    # Alternative 2: Try checking Google Cloud Storage
-    echo -e "${YELLOW}Trying to download from Cloud Storage...${NC}"
-    if gcloud storage cp gs://firebase-preview-drop/extension-builds/firestore-incremental-capture/restore-firestore.jar ./restore-firestore.jar 2>/dev/null; then
-      echo -e "${GREEN}JAR file downloaded successfully from Cloud Storage.${NC}"
-      SUCCESS_TASKS+=("${GREEN}${TICK} Successfully downloaded assets.")
-      exit 0
-    fi
-    
-    # If all attempts fail
-    echo -e "${RED}Failed to download a valid JAR file from all known locations.${NC}"
-    echo -e "${YELLOW}You may need to build the JAR from source or contact Firebase support.${NC}"
-    FAILED_TASKS+=("${RED}${CROSS} Failed to download assets.")
-    exit 1
-  else
-    echo -e "${GREEN}JAR file downloaded successfully.${NC}"
-    SUCCESS_TASKS+=("${GREEN}${TICK} Successfully downloaded assets.")
-  fi
-else
-  echo -e "${RED}Failed to download JAR file.${NC}"
+PIPELINE_URL="https://github.com/GoogleCloudPlatform/firebase-extensions/releases/download/${PIPELINE_RELEASE}/restore-firestore.jar"
+
+echo -e "${YELLOW}Downloading the JAR file (${PIPELINE_RELEASE})...${NC}"
+
+download_failed() {
+  echo -e "${RED}$1${NC}"
   FAILED_TASKS+=("${RED}${CROSS} Failed to download assets.")
-  exit 1
+}
+
+# This file is sourced by run.sh, so it must return rather than exit - an exit
+# here would skip every remaining setup step and still report success.
+if ! curl -fsSL -o restore-firestore.jar "$PIPELINE_URL"; then
+  download_failed "Failed to download the JAR from ${PIPELINE_URL}."
+elif [ "$PIPELINE_SHA256" = "REPLACE_WITH_RELEASE_DIGEST" ]; then
+  download_failed "No pinned checksum is configured for ${PIPELINE_RELEASE}; refusing to use the download."
+elif ! echo "${PIPELINE_SHA256}  restore-firestore.jar" | shasum -a 256 -c - >/dev/null 2>&1; then
+  download_failed "Checksum mismatch: ${PIPELINE_URL} does not match the digest pinned in this extension version."
+  rm -f restore-firestore.jar
+else
+  echo -e "${GREEN}JAR file downloaded and verified.${NC}"
+  SUCCESS_TASKS+=("${GREEN}${TICK} Successfully downloaded assets.")
 fi

--- a/firestore-incremental-capture/install/functions/download_restore_firestore.sh
+++ b/firestore-incremental-capture/install/functions/download_restore_firestore.sh
@@ -4,7 +4,7 @@
 # Bump PIPELINE_RELEASE and PIPELINE_SHA256 together, in the same extension
 # version bump that ships the new pipeline.
 PIPELINE_RELEASE="firestore-incremental-capture-pipeline-v0.1.0"
-PIPELINE_SHA256="REPLACE_WITH_RELEASE_DIGEST"
+PIPELINE_SHA256="41c59a69a553a55d603763fca146b49e00e2e63139e9cf029c55a1ce8ee47ef8"
 
 PIPELINE_URL="https://github.com/GoogleCloudPlatform/firebase-extensions/releases/download/${PIPELINE_RELEASE}/restore-firestore.jar"
 
@@ -23,7 +23,7 @@ download_failed() {
 # here would skip every remaining setup step and still report success.
 if ! curl -fsSL -o restore-firestore.jar "$PIPELINE_URL"; then
   download_failed "Failed to download the JAR from ${PIPELINE_URL}."
-elif [ "$PIPELINE_SHA256" = "REPLACE_WITH_RELEASE_DIGEST" ]; then
+elif [ "$PIPELINE_SHA256" = "41c59a69a553a55d603763fca146b49e00e2e63139e9cf029c55a1ce8ee47ef8" ]; then
   download_failed "No pinned checksum is configured for ${PIPELINE_RELEASE}; refusing to use the download."
 elif ! echo "${PIPELINE_SHA256}  restore-firestore.jar" | shasum -a 256 -c - >/dev/null 2>&1; then
   download_failed "Checksum mismatch: ${PIPELINE_URL} does not match the digest pinned in this extension version."


### PR DESCRIPTION
`download_restore_firestore.sh` fetched the restoration jar from `raw/main`:

```
https://github.com/GoogleCloudPlatform/firebase-extensions/raw/main/firestore-incremental-capture-pipeline/target/restore-firestore.jar
```

That script ships inside each published version and re-reads the URL at install time, so every installation - including versions published years ago - resolves to whatever blob sits at that path when it runs. There is no version signal in the artifact and no way for a user to pin one. Rebuilding the committed jar would have swapped the pipeline under every existing install, onto a build that install was never tested against.

## What changes

The download targets a release tag pinned per extension version and verifies a SHA-256 recorded in the script:

```bash
PIPELINE_RELEASE="firestore-incremental-capture-pipeline-v0.1.0"
PIPELINE_SHA256="REPLACE_WITH_RELEASE_DIGEST"
```

It fails closed - a failed download, an unset digest, or a mismatch all record a failed task and leave no jar behind. The previous `file | grep -q HTML` check would have accepted a 134-byte Git LFS pointer as a valid jar.

The old fallbacks are gone: one pointed at a `firestore-incremental-capture-pipeline` path in `firebase/extensions` that does not exist there (the pipeline has only ever lived in this repo, so that fetch returns a 404 page), and one at a Cloud Storage bucket outside this repo's control.

## Existing users are unaffected until they upgrade

The jar served from `main` is frozen - #1137 adds a CI guard that fails any PR changing it - so versions before 0.0.13 keep resolving exactly the build they always have.

Upgrading is recommended rather than urgent, and PREINSTALL, the README and the changelog say so in those terms: the pinned build is the tested one, and the frozen build targets Apache Beam 2.51.0, which Dataflow [deprecated in October 2024](https://cloud.google.com/dataflow/docs/support/sdk-version-support-status). Deprecated SDKs keep running; decommissioned ones do not, and restoration is the worst place to discover that. Upgrading does not touch captured data or the BigQuery changelog, but the setup script must be re-run so the Flex Template is rebuilt from the pinned jar.

## Also fixed

`run.sh` **sources** this step, so the fallback paths' `exit 0` ended the entire run - skipping PITR, Firestore, Artifact Registry, service account and Flex Template setup - while printing "All operations completed successfully". The step now returns instead of exiting.

## Blocked on

1. #1137 merges and a `firestore-incremental-capture-pipeline-v0.1.0` tag is pushed, cutting the release.
2. `PIPELINE_SHA256` is replaced with that release's digest.

`guard-incremental-capture-pin.yaml` enforces this: it fails while `PIPELINE_SHA256` is the placeholder, so **this PR is expected to show red until the release exists and the digest is filled in**. That is the gate working, not a broken check - it makes the ordering unskippable rather than relying on someone remembering it.

Until then the script also refuses to use the download rather than trusting it, so even a premature publish fails setup loudly instead of silently installing an unverified jar.

Version bumped 0.0.12 -> 0.0.13; README regenerated with `generate-readme`.



