### PR TITLE
fix(firestore-incremental-capture): dedupe restores by path

### DIFF
--- a/firestore-incremental-capture-pipeline/src/main/java/com/pipeline/IncrementalCaptureLog.java
+++ b/firestore-incremental-capture-pipeline/src/main/java/com/pipeline/IncrementalCaptureLog.java
@@ -78,7 +78,7 @@ public class IncrementalCaptureLog
         "        beforeData," +
         "        afterData," +
         "        timestamp," +
-        "        ROW_NUMBER() OVER(PARTITION BY documentId ORDER BY timestamp DESC) as rank" +
+        "        ROW_NUMBER() OVER(PARTITION BY documentPath ORDER BY timestamp DESC) as rank" +
         "    FROM `" + projectId + "." + datasetId + "." + tableId + "`" +
         "    WHERE timestamp < TIMESTAMP('" + (timestamp) + "') " +
         ") " +
@@ -91,7 +91,7 @@ public class IncrementalCaptureLog
         "    timestamp " +
         "FROM RankedChanges " +
         "WHERE rank = 1 " +
-        "ORDER BY documentId, timestamp DESC";
+        "ORDER BY documentPath, timestamp DESC";
 
     return query;
 


### PR DESCRIPTION
## Summary

- deduplicate incremental-capture restore rows by full Firestore document path
- order the selected restore rows by the same collision-free key
- preserve independent documents that share a final document ID across collections

Fixes #1138

## Testing

- `mvn -q -DskipTests package` in `firestore-incremental-capture-pipeline`
- `git diff --check`
