### PR TITLE
fix(firestore-vector-search): backfill on model changes

### DIFF
--- a/firestore-vector-search/functions/__tests__/backfill.test.ts
+++ b/firestore-vector-search/functions/__tests__/backfill.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {embeddingMetadataChanged} from '../src/backfill';
+
+const current = {
+  embeddingProvider: 'vertex',
+  embeddingModel: 'gemini-embedding-001',
+  dimension: 768,
+  inputField: 'content',
+  outputField: 'embedding',
+};
+
+describe('embeddingMetadataChanged', () => {
+  test('keeps matching embedding metadata', () => {
+    expect(embeddingMetadataChanged(current, current)).toBe(false);
+  });
+
+  test('requires a backfill when the embedding model changes', () => {
+    expect(
+      embeddingMetadataChanged(
+        {...current, embeddingModel: 'text-embedding-004'},
+        current
+      )
+    ).toBe(true);
+  });
+});

--- a/firestore-vector-search/functions/src/backfill.ts
+++ b/firestore-vector-search/functions/src/backfill.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {DocumentData} from '@google-cloud/firestore';
+
+interface EmbeddingMetadata {
+  embeddingProvider: string;
+  embeddingModel: string;
+  dimension: number | undefined;
+  inputField: string;
+  outputField: string;
+}
+
+export const embeddingMetadataChanged = (
+  metadata: DocumentData | undefined,
+  current: EmbeddingMetadata
+) =>
+  !metadata ||
+  metadata.embeddingProvider !== current.embeddingProvider ||
+  metadata.embeddingModel !== current.embeddingModel ||
+  metadata.dimension !== current.dimension ||
+  metadata.inputField !== current.inputField ||
+  metadata.outputField !== current.outputField;

--- a/firestore-vector-search/functions/src/config.ts
+++ b/firestore-vector-search/functions/src/config.ts
@@ -16,6 +16,7 @@
 
 import * as admin from 'firebase-admin/app';
 import * as Firestore from '@google-cloud/firestore';
+import {getEmbeddingModel} from './embeddings/client/models';
 
 admin.initializeApp();
 
@@ -83,6 +84,10 @@ export const config = {
       : undefined,
   },
   embeddingProvider: embeddingProvider,
+  embeddingModel: getEmbeddingModel(
+    embeddingProvider,
+    process.env.CUSTOM_EMBEDDINGS_ENDPOINT
+  ),
   multimodal: embeddingProvider === EmbeddingProvider.Multimodal,
   vectorStoreProvider: 'firestore',
   geminiApiKey: process.env.GEMINI_API_KEY,

--- a/firestore-vector-search/functions/src/embeddings/client/genkit.ts
+++ b/firestore-vector-search/functions/src/embeddings/client/genkit.ts
@@ -18,6 +18,7 @@ import {EmbedderReference, Genkit, genkit} from 'genkit';
 import {config} from '../../config';
 import {GenkitPluginV2} from 'genkit/plugin';
 import {googleAI, vertexAI} from '@genkit-ai/google-genai';
+import {GEMINI_EMBEDDING_MODEL} from './models';
 
 export class GenkitEmbedClient {
   provider: 'vertexai' | 'googleai' | 'multimodal';
@@ -38,7 +39,7 @@ export class GenkitEmbedClient {
     let plugins: GenkitPluginV2[] = [];
 
     if (this.provider === 'vertexai') {
-      this.embedder = vertexAI.embedder('gemini-embedding-001', {
+      this.embedder = vertexAI.embedder(GEMINI_EMBEDDING_MODEL, {
         outputDimensionality: 768,
       });
       plugins = [
@@ -48,7 +49,7 @@ export class GenkitEmbedClient {
       ];
     }
     if (this.provider === 'googleai') {
-      this.embedder = googleAI.embedder('gemini-embedding-001', {
+      this.embedder = googleAI.embedder(GEMINI_EMBEDDING_MODEL, {
         outputDimensionality: 768,
       });
       plugins = [

--- a/firestore-vector-search/functions/src/embeddings/client/models.ts
+++ b/firestore-vector-search/functions/src/embeddings/client/models.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const GEMINI_EMBEDDING_MODEL = 'gemini-embedding-001';
+export const MULTIMODAL_EMBEDDING_MODEL = 'multimodalembedding@001';
+export const OPENAI_EMBEDDING_MODEL = 'text-embedding-ada-002';
+
+export const getEmbeddingModel = (
+  provider: string,
+  customEndpoint?: string
+) => {
+  switch (provider) {
+    case 'gemini':
+    case 'vertex':
+      return GEMINI_EMBEDDING_MODEL;
+    case 'multimodal':
+      return MULTIMODAL_EMBEDDING_MODEL;
+    case 'openai':
+      return OPENAI_EMBEDDING_MODEL;
+    case 'custom':
+      return customEndpoint || 'custom';
+    default:
+      return provider;
+  }
+};

--- a/firestore-vector-search/functions/src/embeddings/client/multimodal/index.ts
+++ b/firestore-vector-search/functions/src/embeddings/client/multimodal/index.ts
@@ -16,6 +16,7 @@
 
 import {EmbedClient} from '../base_class';
 import {config} from '../../../config';
+import {MULTIMODAL_EMBEDDING_MODEL} from '../models';
 import * as admin from 'firebase-admin';
 import {VertexAI} from '@google-cloud/vertexai';
 import fetch from 'node-fetch';
@@ -80,7 +81,7 @@ export class MultimodalEmbeddingClient extends EmbedClient {
     // POST https://us-central1-aiplatform.googleapis.com/v1/projects/PROJECT_ID/locations/us-central1/publishers/google/models/multimodalembedding@001:predict
 
     // TODO: do we add config location?
-    const endpoint = `https://us-central1-aiplatform.googleapis.com/v1/projects/${config.projectId}/locations/us-central-1/publishers/google/models/multimodalembedding@001:predict`;
+    const endpoint = `https://us-central1-aiplatform.googleapis.com/v1/projects/${config.projectId}/locations/us-central-1/publishers/google/models/${MULTIMODAL_EMBEDDING_MODEL}:predict`;
 
     const promises: Promise<{
       image?: {bytesBase64Encoded: string; mimeType: string};

--- a/firestore-vector-search/functions/src/embeddings/client/text/open_ai.ts
+++ b/firestore-vector-search/functions/src/embeddings/client/text/open_ai.ts
@@ -15,6 +15,7 @@
  */
 
 import OpenAI from 'openai';
+import {OPENAI_EMBEDDING_MODEL} from '../models';
 import {EmbedClient} from '../base_class';
 import {config} from '../../../config';
 
@@ -42,7 +43,7 @@ export class OpenAIEmbedClient extends EmbedClient {
     }
 
     const embeddingRequest: OpenAI.Embeddings.EmbeddingCreateParams = {
-      model: 'text-embedding-ada-002',
+      model: OPENAI_EMBEDDING_MODEL,
       input: batch,
     };
 

--- a/firestore-vector-search/functions/src/index.ts
+++ b/firestore-vector-search/functions/src/index.ts
@@ -32,12 +32,21 @@ import {DocumentData} from '@google-cloud/firestore';
 import {getExtensions} from 'firebase-admin/extensions';
 import * as logs from './logs';
 import {createIndex} from './queries/setup';
+import {embeddingMetadataChanged} from './backfill';
 
 logs.init();
 
 // Embeddings
 
 const runtime = getExtensions().runtime();
+
+const embeddingMetadata = {
+  embeddingProvider: config.embeddingProvider,
+  embeddingModel: config.embeddingModel,
+  dimension: config.dimension,
+  inputField: config.inputField,
+  outputField: config.outputField,
+};
 
 export const embedOnWrite = functions.firestore
   .document(`${config.collectionName}/{docId}`)
@@ -52,13 +61,7 @@ const shouldDoBackfill = async (metadata?: DocumentData) => {
     return false;
   }
   // if the embedding provider or model is different, run the backfill
-  if (
-    !metadata ||
-    metadata.embeddingProvider !== config.embeddingProvider ||
-    metadata.dimension !== config.dimension ||
-    metadata.inputField !== config.inputField ||
-    metadata.outputField !== config.outputField
-  ) {
+  if (embeddingMetadataChanged(metadata, embeddingMetadata)) {
     await runtime.setProcessingState(
       'NONE',
       `Updating Embeddings for collection ${config.collectionName}.`
@@ -75,12 +78,7 @@ const backfillOptions: FirestoreBackfillOptions = {
   shouldDoBackfill,
   statusField: config.statusField,
   extensionInstanceId: config.instanceId,
-  metadata: {
-    embeddingProvider: config.embeddingProvider,
-    dimension: config.dimension,
-    inputField: config.inputField,
-    outputField: config.outputField,
-  },
+  metadata: embeddingMetadata,
 };
 
 //  Backfill
@@ -121,9 +119,7 @@ const updateOptions: FirestoreBackfillOptions = {
   metadataDocumentPath: config.indexMetadataDocumentPath,
   shouldDoBackfill,
   extensionInstanceId: config.instanceId,
-  metadata: {
-    embeddingProvider: config.embeddingProvider,
-  },
+  metadata: embeddingMetadata,
 };
 
 const onUpdateTrigger = firestoreProcessBackfillTrigger(


### PR DESCRIPTION
## Summary

- record the concrete embedding model alongside the provider in backfill metadata
- compare the stored model when deciding whether existing documents need new embeddings
- share model identifiers with the clients so metadata cannot drift from the model actually used
- retain complete metadata during both install and update backfills

Fixes #1140

## Testing

- `npm test -- --runInBand` (39 passed, 1 skipped)
- `npm run compile`
- `git diff --check`
