### PR TITLE
fix(firestore-incremental-capture-pipeline): dedupe changelog rows by document path

### DIFF
--- a/firestore-incremental-capture-pipeline/src/main/java/com/pipeline/IncrementalCaptureLog.java
+++ b/firestore-incremental-capture-pipeline/src/main/java/com/pipeline/IncrementalCaptureLog.java
@@ -68,7 +68,7 @@ public class IncrementalCaptureLog
         }).fromQuery(constructQuery(formattedTimestamp)).usingStandardSql().withTemplateCompatibility());
   }
 
-  private String constructQuery(String timestamp) {
+  String constructQuery(String timestamp) {
 
     LOG.info("Querying BigQuery for changes before timestamp: " + timestamp);
     String query = "WITH RankedChanges AS (" +
@@ -79,7 +79,7 @@ public class IncrementalCaptureLog
         "        beforeData," +
         "        afterData," +
         "        timestamp," +
-        "        ROW_NUMBER() OVER(PARTITION BY documentId ORDER BY timestamp DESC) as rank" +
+        "        ROW_NUMBER() OVER(PARTITION BY documentPath ORDER BY timestamp DESC) as rank" +
         "    FROM `" + projectId + "." + datasetId + "." + tableId + "`" +
         "    WHERE timestamp < TIMESTAMP('" + (timestamp) + "') " +
         ") " +
@@ -92,7 +92,7 @@ public class IncrementalCaptureLog
         "    timestamp " +
         "FROM RankedChanges " +
         "WHERE rank = 1 " +
-        "ORDER BY documentId, timestamp DESC";
+        "ORDER BY documentPath, timestamp DESC";
 
     return query;
 

--- a/firestore-incremental-capture-pipeline/src/test/java/com/pipeline/IncrementalCaptureLogTest.java
+++ b/firestore-incremental-capture-pipeline/src/test/java/com/pipeline/IncrementalCaptureLogTest.java
@@ -17,6 +17,8 @@
 package com.pipeline;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
@@ -77,6 +79,18 @@ public class IncrementalCaptureLogTest {
 
     assertEquals(1, kv.getValue().getFieldsCount());
     assertEquals("Ada", kv.getValue().getFieldsOrThrow("name").getStringValue());
+  }
+
+  @Test
+  public void dedupesChangelogRowsByDocumentPath() {
+    IncrementalCaptureLog captureLog = new IncrementalCaptureLog(
+        PROJECT_ID, org.joda.time.Instant.now(), DATABASE_ID, "test_dataset", "test_table");
+
+    String query = captureLog.constructQuery("2026-01-01 00:00:00");
+
+    assertTrue(query.contains("ROW_NUMBER() OVER(PARTITION BY documentPath ORDER BY timestamp DESC)"));
+    assertFalse(query.contains("PARTITION BY documentId"));
+    assertTrue(query.contains("ORDER BY documentPath, timestamp DESC"));
   }
 
   @Test


### PR DESCRIPTION
The restoration pipeline dedupes changelog rows with ROW_NUMBER() OVER(PARTITION BY documentId ORDER BY timestamp DESC) and keeps rank = 1. documentId is the bare last path segment, so documents that share an id across collections - users/{uid} beside profiles/{uid}, or every parent's .../settings/preferences - collapse into one partition and all but the newest row are silently dropped from the replay. Affected documents stay at their PITR baseline, and a delete can even be reverted by a newer same-id row elsewhere.

The fix partitions by documentPath and uses documentPath in the final ORDER BY. documentPath is REQUIRED in the changelog schema, so no schema change or backfill is needed. constructQuery is now package-private so the new test (dedupesChangelogRowsByDocumentPath) can pin the generated SQL; all 5 tests pass via mvn clean package.

Note: this changes restoration output. Restores that previously "succeeded" will replay more rows and produce different, correct data, and the Firestore write volume of a restoration can increase for affected databases. Verification is unit-test level only - no live Dataflow run.

This merge fixes source only. The tracked target/restore-firestore.jar is deliberately frozen and still carries the old query, so installed users keep running the bug until the fix ships through the release channel in #1137 and the pinned download in #1139.

Fixes #1138
