### PR TITLE
fix(firestore-incremental-capture-pipeline): restore documentReference, binary and null fields

### DIFF
--- a/firestore-incremental-capture-pipeline/src/main/java/com/pipeline/FirestoreReconstructor.java
+++ b/firestore-incremental-capture-pipeline/src/main/java/com/pipeline/FirestoreReconstructor.java
@@ -25,12 +25,18 @@ import com.google.firestore.v1.MapValue;
 import com.google.firestore.v1.Value;
 
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
 import java.time.Instant;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class FirestoreReconstructor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FirestoreReconstructor.class);
 
     public enum FirestoreType {
         STRING,
@@ -122,7 +128,10 @@ public class FirestoreReconstructor {
                         val = Value.newBuilder().setTimestampValue(timestamp).build();
                         break;
 
+                    // The serializer emits "documentReference"; "reference" is kept for
+                    // changelog rows written by older serializer versions.
                     case "REFERENCE":
+                    case "DOCUMENTREFERENCE":
 
                         String pathString = entryValueObject.get("value").getAsString();
 
@@ -135,8 +144,17 @@ public class FirestoreReconstructor {
                         val = Value.newBuilder().setReferenceValue(fullReferenceString)
                                 .build();
                         break;
+                    case "NULL":
+                        val = Value.newBuilder().setNullValue(com.google.protobuf.NullValue.NULL_VALUE).build();
+                        break;
+                    case "BINARY":
+                        byte[] bytes = Base64.getDecoder().decode(entryValueObject.get("value").getAsString());
+                        val = Value.newBuilder().setBytesValue(com.google.protobuf.ByteString.copyFrom(bytes))
+                                .build();
+                        break;
                     default:
-                        val = null;
+                        LOG.warn("Skipping field '{}': unknown serialized type tag '{}'",
+                                entry.getKey(), entryValueObject.get("type").getAsString());
                         continue;
                 }
 

--- a/firestore-incremental-capture-pipeline/src/test/java/com/pipeline/FirestoreReconstructorTest.java
+++ b/firestore-incremental-capture-pipeline/src/test/java/com/pipeline/FirestoreReconstructorTest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pipeline;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.google.firestore.v1.Value;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.google.protobuf.NullValue;
+
+public class FirestoreReconstructorTest {
+
+  private static final String PROJECT_ID = "test-project";
+  private static final String DATABASE_ID = "test-db";
+
+  private static Map<String, Value> build(String json) {
+    JsonElement data = JsonParser.parseString(json);
+    return FirestoreReconstructor.buildFirestoreMap(data, PROJECT_ID, DATABASE_ID);
+  }
+
+  @Test
+  public void documentReferenceBecomesAFullyQualifiedReferenceValue() {
+    Map<String, Value> fields = build(
+        "{\"ref\":{\"type\":\"documentReference\",\"value\":\"users/abc\"}}");
+
+    assertEquals(1, fields.size());
+    assertEquals(
+        "projects/test-project/databases/test-db/documents/users/abc",
+        fields.get("ref").getReferenceValue());
+  }
+
+  @Test
+  public void nullBecomesANullValue() {
+    Map<String, Value> fields = build("{\"gone\":{\"type\":\"null\",\"value\":null}}");
+
+    assertEquals(1, fields.size());
+    assertEquals(NullValue.NULL_VALUE, fields.get("gone").getNullValue());
+    assertEquals(Value.ValueTypeCase.NULL_VALUE, fields.get("gone").getValueTypeCase());
+  }
+
+  @Test
+  public void binaryDecodesBase64IntoBytes() {
+    byte[] payload = "hello bytes".getBytes(StandardCharsets.UTF_8);
+    String base64 = Base64.getEncoder().encodeToString(payload);
+
+    Map<String, Value> fields = build(
+        "{\"blob\":{\"type\":\"binary\",\"value\":\"" + base64 + "\"}}");
+
+    assertEquals(1, fields.size());
+    assertEquals(
+        com.google.protobuf.ByteString.copyFrom(payload),
+        fields.get("blob").getBytesValue());
+  }
+
+  @Test
+  public void unknownTypeTagIsSkippedWithoutThrowing() {
+    Map<String, Value> fields = build(
+        "{\"mystery\":{\"type\":\"vector\",\"value\":\"?\"},"
+            + "\"name\":{\"type\":\"string\",\"value\":\"Ada\"}}");
+
+    assertEquals(1, fields.size());
+    assertTrue(fields.containsKey("name"));
+    assertEquals("Ada", fields.get("name").getStringValue());
+  }
+}


### PR DESCRIPTION
The restoration pipeline's FirestoreReconstructor switches on the uppercased type tag from the changelog JSON, but had no cases for three tags the extension's serializer actually emits: documentReference, binary, and null (firestore_serializer.ts lines 28, 91, 101). The default branch did a bare continue, so those fields were silently dropped from every restored document.

This adds a DOCUMENTREFERENCE case sharing the existing REFERENCE handling (REFERENCE kept for any older changelog rows), a NULL case producing NullValue.NULL_VALUE, and a BINARY case decoding the payload as base64 into bytesValue - the serializer encodes Buffers with property.toString('base64'). The default branch now logs the unknown tag via slf4j instead of dropping it silently, while still skipping the field.

New FirestoreReconstructorTest covers all three tags plus the unknown-tag skip; all tests pass under mvn clean package. Caveats: the wire format is inferred from the serializer source (there is no TS deserializer to cross-check), and this is unit-tested only - no live restore run was performed.

This merge fixes source only. The tracked target/restore-firestore.jar is deliberately frozen, so installed users get the fix through the release channel in #1137 and the pinned download in #1139. Arrays remain broken on both sides of the wire format - tracked separately in #1147.

Fixes #1144
