### PR TITLE
fix(firestore-incremental-capture-pipeline): make the shaded jar reproducible

### DIFF
--- a/firestore-incremental-capture-pipeline/pom.xml
+++ b/firestore-incremental-capture-pipeline/pom.xml
@@ -14,6 +14,10 @@
              whichever JDK happens to run the build. -->
         <maven.compiler.release>11</maven.compiler.release>
         <beam.version>2.75.0</beam.version>
+        <!-- Reproducible builds: without a fixed timestamp the shaded jar
+             embeds wall-clock zip entries, so no rebuild from a tag can ever
+             byte-match the released asset. Bump alongside the version. -->
+        <project.build.outputTimestamp>2026-09-01T00:00:00Z</project.build.outputTimestamp>
     </properties>
     <build>
         <finalName>restore-firestore</finalName>
@@ -21,7 +25,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
Two consecutive builds of the same commit produced different jars - the pom has no project.build.outputTimestamp, so the shade plugin embeds wall-clock zip timestamps. That means no one could ever rebuild a tagged release and byte-compare it against the published asset; trust in the artifact would rest entirely on the provenance attestation.

This pins project.build.outputTimestamp (bump it alongside the version) and updates maven-shade-plugin 3.2.4 to 3.6.0 for its reproducible-archive handling. Verified locally: two consecutive mvn clean package runs now produce identical SHA-256 digests, and all 9 tests pass.

Wants to land before the first firestore-incremental-capture-pipeline-v0.1.0 tag is cut, so the first release asset is reproducible from day one - the tag ruleset makes releases permanent, so a non-reproducible v0.1.0 would stay that way. The tracked target/restore-firestore.jar is untouched. Reproducibility was verified on one machine only; cross-environment byte-equality (differing JDK builds of 11) is not claimed.