### PR TITLE
fix(firestore-incremental-capture-pipeline): restore tagged array elements

### DIFF
--- a/firestore-incremental-capture-pipeline/src/main/java/com/pipeline/FirestoreReconstructor.java
+++ b/firestore-incremental-capture-pipeline/src/main/java/com/pipeline/FirestoreReconstructor.java
@@ -58,123 +58,159 @@ public class FirestoreReconstructor {
         for (Map.Entry<String, JsonElement> entry : dataObject.entrySet()) {
             JsonElement valueElem = entry.getValue();
 
-            if (valueElem.isJsonObject() && valueElem.getAsJsonObject().has("type")
-                    && valueElem.getAsJsonObject().has("value")) {
-                JsonObject entryValueObject = valueElem.getAsJsonObject();
-                String valueType = entryValueObject.get("type").getAsString().toUpperCase();
-
-                Value val;
-                switch (valueType) {
-                    case "STRING":
-                        val = Value.newBuilder().setStringValue(entryValueObject.get("value").getAsString()).build();
-                        break;
-                    case "NUMBER":
-                        val = Value.newBuilder().setDoubleValue(entryValueObject.get("value").getAsDouble()).build();
-                        break;
-                    case "BOOLEAN":
-                        String originalValue = entryValueObject.get("value").getAsString();
-
-                        if (originalValue.equals("true")) {
-                            val = Value.newBuilder().setBooleanValue(true).build();
-                        } else {
-                            val = Value.newBuilder().setBooleanValue(false).build();
-                        }
-                        break;
-                    case "OBJECT":
-                        val = Value.newBuilder().setMapValue(
-                                MapValue.newBuilder().putAllFields(
-                                        buildFirestoreMap(entryValueObject.get("value"), projectId, databaseId)))
-                                .build();
-                        break;
-                    case "MAP":
-                        val = Value.newBuilder().setMapValue(
-                                MapValue.newBuilder().putAllFields(
-                                        buildFirestoreMap(entryValueObject.get("value"), projectId, databaseId)))
-                                .build();
-                        break;
-                    case "ARRAY":
-                        val = Value.newBuilder().setArrayValue(
-                                ArrayValue.newBuilder().addAllValues(
-                                        buildFirestoreList(entryValueObject.get("value").getAsJsonArray(), projectId,
-                                                databaseId)))
-                                .build();
-                        break;
-                    case "GEOPOINT":
-                        JsonObject geopointValue = entryValueObject.get("value").getAsJsonObject();
-                        JsonObject latitude = geopointValue.get("latitude").getAsJsonObject();
-                        JsonObject longitude = geopointValue.get("longitude").getAsJsonObject();
-
-                        Double latitudeValue = latitude.get("value").getAsDouble();
-                        Double longitudeValue = longitude.get("value").getAsDouble();
-
-                        val = Value.newBuilder().setGeoPointValue(
-                                com.google.type.LatLng.newBuilder().setLatitude(latitudeValue)
-                                        .setLongitude(longitudeValue)
-                                        .build())
-                                .build();
-                        break;
-                    case "TIMESTAMP":
-
-                        // parse the timestamp value as an Instant
-                        Instant instant = Instant.parse(entryValueObject.get("value").getAsString());
-
-                        long epochSecond = instant.getEpochSecond();
-                        int nanoSecond = instant.getNano();
-
-                        Timestamp timestamp = Timestamp.newBuilder().setSeconds(epochSecond).setNanos(nanoSecond)
-                                .build();
-
-                        // convert to seconds and nanoseconds
-                        val = Value.newBuilder().setTimestampValue(timestamp).build();
-                        break;
-
-                    // The serializer emits "documentReference"; "reference" is kept for
-                    // changelog rows written by older serializer versions.
-                    case "REFERENCE":
-                    case "DOCUMENTREFERENCE":
-
-                        String pathString = entryValueObject.get("value").getAsString();
-
-                        String fullReferenceString = String.format(
-                                "projects/%s/databases/%s/documents/%s",
-                                projectId,
-                                databaseId,
-                                pathString);
-
-                        val = Value.newBuilder().setReferenceValue(fullReferenceString)
-                                .build();
-                        break;
-                    case "NULL":
-                        val = Value.newBuilder().setNullValue(com.google.protobuf.NullValue.NULL_VALUE).build();
-                        break;
-                    case "BINARY":
-                        byte[] bytes = Base64.getDecoder().decode(entryValueObject.get("value").getAsString());
-                        val = Value.newBuilder().setBytesValue(com.google.protobuf.ByteString.copyFrom(bytes))
-                                .build();
-                        break;
-                    default:
-                        LOG.warn("Skipping field '{}': unknown serialized type tag '{}'",
-                                entry.getKey(), entryValueObject.get("type").getAsString());
-                        continue;
-                }
-
-                fieldsMap.put(entry.getKey(), val);
+            if (!isTaggedValue(valueElem)) {
+                continue;
             }
+
+            JsonObject entryValueObject = valueElem.getAsJsonObject();
+            Value val = buildTaggedValue(entryValueObject, projectId, databaseId);
+
+            if (val == null) {
+                LOG.warn("Skipping field '{}': cannot reconstruct serialized type tag '{}'",
+                        entry.getKey(), entryValueObject.get("type").getAsString());
+                continue;
+            }
+
+            fieldsMap.put(entry.getKey(), val);
         }
 
         // log it
         return fieldsMap;
     }
 
+    // A serialized value is a JSON object carrying a string "type" tag and a
+    // "value". A map serialized as a bare field map can hold entries named
+    // "type" and "value", but those entries are themselves objects, so
+    // requiring a string tag keeps the two shapes apart.
+    private static boolean isTaggedValue(JsonElement element) {
+        if (!element.isJsonObject()) {
+            return false;
+        }
+
+        JsonObject object = element.getAsJsonObject();
+        JsonElement type = object.get("type");
+
+        return type != null && type.isJsonPrimitive() && type.getAsJsonPrimitive().isString()
+                && object.has("value");
+    }
+
+    // Builds the Value a serialized {type, value} object describes, or null
+    // when the tag is unknown or its value does not have the shape the tag
+    // implies. Changelog rows corrupted when they were written are
+    // unrecoverable, so the caller skips them rather than failing the job.
+    private static Value buildTaggedValue(JsonObject taggedValue, String projectId, String databaseId) {
+
+        String valueType = taggedValue.get("type").getAsString().toUpperCase();
+        JsonElement value = taggedValue.get("value");
+
+        switch (valueType) {
+            case "STRING":
+                return Value.newBuilder().setStringValue(value.getAsString()).build();
+            case "NUMBER":
+                return Value.newBuilder().setDoubleValue(value.getAsDouble()).build();
+            case "BOOLEAN":
+                return Value.newBuilder().setBooleanValue("true".equals(value.getAsString())).build();
+            case "OBJECT":
+            case "MAP":
+                if (!value.isJsonObject()) {
+                    return null;
+                }
+
+                return Value.newBuilder().setMapValue(
+                        MapValue.newBuilder().putAllFields(
+                                buildFirestoreMap(value, projectId, databaseId)))
+                        .build();
+            case "ARRAY":
+                if (!value.isJsonArray()) {
+                    return null;
+                }
+
+                return Value.newBuilder().setArrayValue(
+                        ArrayValue.newBuilder().addAllValues(
+                                buildFirestoreList(value.getAsJsonArray(), projectId, databaseId)))
+                        .build();
+            case "GEOPOINT":
+                if (!value.isJsonObject()) {
+                    return null;
+                }
+
+                JsonObject geopointValue = value.getAsJsonObject();
+                JsonObject latitude = geopointValue.get("latitude").getAsJsonObject();
+                JsonObject longitude = geopointValue.get("longitude").getAsJsonObject();
+
+                Double latitudeValue = latitude.get("value").getAsDouble();
+                Double longitudeValue = longitude.get("value").getAsDouble();
+
+                return Value.newBuilder().setGeoPointValue(
+                        com.google.type.LatLng.newBuilder().setLatitude(latitudeValue)
+                                .setLongitude(longitudeValue)
+                                .build())
+                        .build();
+            case "TIMESTAMP":
+
+                // parse the timestamp value as an Instant
+                Instant instant = Instant.parse(value.getAsString());
+
+                long epochSecond = instant.getEpochSecond();
+                int nanoSecond = instant.getNano();
+
+                Timestamp timestamp = Timestamp.newBuilder().setSeconds(epochSecond).setNanos(nanoSecond)
+                        .build();
+
+                // convert to seconds and nanoseconds
+                return Value.newBuilder().setTimestampValue(timestamp).build();
+
+            // The serializer emits "documentReference"; "reference" is kept for
+            // changelog rows written by older serializer versions.
+            case "REFERENCE":
+            case "DOCUMENTREFERENCE":
+
+                String fullReferenceString = String.format(
+                        "projects/%s/databases/%s/documents/%s",
+                        projectId,
+                        databaseId,
+                        value.getAsString());
+
+                return Value.newBuilder().setReferenceValue(fullReferenceString).build();
+            case "NULL":
+                return Value.newBuilder().setNullValue(com.google.protobuf.NullValue.NULL_VALUE).build();
+            case "BINARY":
+                byte[] bytes = Base64.getDecoder().decode(value.getAsString());
+
+                return Value.newBuilder().setBytesValue(com.google.protobuf.ByteString.copyFrom(bytes)).build();
+            default:
+                return null;
+        }
+    }
+
     private static List<Value> buildFirestoreList(JsonArray arr, String projectId, String databaseId) {
 
         List<Value> lst = new ArrayList<>();
         for (JsonElement el : arr) {
-            Map<String, Value> mapData = buildFirestoreMap(el, projectId, databaseId);
-            Value val = Value.newBuilder().setMapValue(
-                    MapValue.newBuilder().putAllFields(mapData)).build();
+            if (isTaggedValue(el)) {
+                JsonObject taggedValue = el.getAsJsonObject();
+                Value val = buildTaggedValue(taggedValue, projectId, databaseId);
 
-            lst.add(val);
+                if (val == null) {
+                    LOG.warn("Skipping array element: cannot reconstruct serialized type tag '{}'",
+                            taggedValue.get("type").getAsString());
+                    continue;
+                }
+
+                lst.add(val);
+                continue;
+            }
+
+            if (!el.isJsonObject()) {
+                LOG.warn("Skipping array element: expected a serialized value or a field map");
+                continue;
+            }
+
+            // Map elements are serialized as bare field maps, without a "map" tag.
+            Map<String, Value> mapData = buildFirestoreMap(el, projectId, databaseId);
+
+            lst.add(Value.newBuilder().setMapValue(
+                    MapValue.newBuilder().putAllFields(mapData)).build());
         }
 
         return lst;

--- a/firestore-incremental-capture-pipeline/src/main/java/com/pipeline/FirestoreReconstructor.java
+++ b/firestore-incremental-capture-pipeline/src/main/java/com/pipeline/FirestoreReconstructor.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
 import java.time.Instant;
+import java.time.format.DateTimeParseException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,6 +38,12 @@ import org.slf4j.LoggerFactory;
 public class FirestoreReconstructor {
 
     private static final Logger LOG = LoggerFactory.getLogger(FirestoreReconstructor.class);
+
+    // An element that cannot be reconstructed is replaced with null rather than
+    // dropped, so the restored array keeps the length and the element positions
+    // the document was written with.
+    private static final Value UNRECONSTRUCTABLE_ELEMENT = Value.newBuilder()
+            .setNullValue(com.google.protobuf.NullValue.NULL_VALUE).build();
 
     public enum FirestoreType {
         STRING,
@@ -59,6 +66,10 @@ public class FirestoreReconstructor {
             JsonElement valueElem = entry.getValue();
 
             if (!isTaggedValue(valueElem)) {
+                if (valueElem.isJsonObject()) {
+                    LOG.warn("Skipping field '{}': not a serialized value", entry.getKey());
+                }
+
                 continue;
             }
 
@@ -96,8 +107,9 @@ public class FirestoreReconstructor {
 
     // Builds the Value a serialized {type, value} object describes, or null
     // when the tag is unknown or its value does not have the shape the tag
-    // implies. Changelog rows corrupted when they were written are
-    // unrecoverable, so the caller skips them rather than failing the job.
+    // implies. A changelog row corrupted when it was written is unrecoverable,
+    // and it runs inside a BigQueryIO read with no handler, so one bad value
+    // must cost its own field or element rather than the whole restore job.
     private static Value buildTaggedValue(JsonObject taggedValue, String projectId, String databaseId) {
 
         String valueType = taggedValue.get("type").getAsString().toUpperCase();
@@ -105,10 +117,38 @@ public class FirestoreReconstructor {
 
         switch (valueType) {
             case "STRING":
+                if (!value.isJsonPrimitive()) {
+                    return null;
+                }
+
                 return Value.newBuilder().setStringValue(value.getAsString()).build();
             case "NUMBER":
-                return Value.newBuilder().setDoubleValue(value.getAsDouble()).build();
+                if (!value.isJsonPrimitive()) {
+                    return null;
+                }
+
+                // A NaN or Infinity double reaches the changelog as a JSON null,
+                // which JSON cannot represent and this pipeline cannot restore.
+                try {
+                    return Value.newBuilder().setDoubleValue(value.getAsDouble()).build();
+                } catch (NumberFormatException e) {
+                    return null;
+                }
+            case "BIGINT":
+                if (!value.isJsonPrimitive()) {
+                    return null;
+                }
+
+                try {
+                    return Value.newBuilder().setIntegerValue(Long.parseLong(value.getAsString())).build();
+                } catch (NumberFormatException e) {
+                    return null;
+                }
             case "BOOLEAN":
+                if (!value.isJsonPrimitive()) {
+                    return null;
+                }
+
                 return Value.newBuilder().setBooleanValue("true".equals(value.getAsString())).build();
             case "OBJECT":
             case "MAP":
@@ -135,11 +175,12 @@ public class FirestoreReconstructor {
                 }
 
                 JsonObject geopointValue = value.getAsJsonObject();
-                JsonObject latitude = geopointValue.get("latitude").getAsJsonObject();
-                JsonObject longitude = geopointValue.get("longitude").getAsJsonObject();
+                Double latitudeValue = buildCoordinate(geopointValue, "latitude");
+                Double longitudeValue = buildCoordinate(geopointValue, "longitude");
 
-                Double latitudeValue = latitude.get("value").getAsDouble();
-                Double longitudeValue = longitude.get("value").getAsDouble();
+                if (latitudeValue == null || longitudeValue == null) {
+                    return null;
+                }
 
                 return Value.newBuilder().setGeoPointValue(
                         com.google.type.LatLng.newBuilder().setLatitude(latitudeValue)
@@ -147,23 +188,33 @@ public class FirestoreReconstructor {
                                 .build())
                         .build();
             case "TIMESTAMP":
+                if (!value.isJsonPrimitive()) {
+                    return null;
+                }
 
-                // parse the timestamp value as an Instant
-                Instant instant = Instant.parse(value.getAsString());
+                try {
+                    // parse the timestamp value as an Instant
+                    Instant instant = Instant.parse(value.getAsString());
 
-                long epochSecond = instant.getEpochSecond();
-                int nanoSecond = instant.getNano();
+                    long epochSecond = instant.getEpochSecond();
+                    int nanoSecond = instant.getNano();
 
-                Timestamp timestamp = Timestamp.newBuilder().setSeconds(epochSecond).setNanos(nanoSecond)
-                        .build();
+                    Timestamp timestamp = Timestamp.newBuilder().setSeconds(epochSecond).setNanos(nanoSecond)
+                            .build();
 
-                // convert to seconds and nanoseconds
-                return Value.newBuilder().setTimestampValue(timestamp).build();
+                    // convert to seconds and nanoseconds
+                    return Value.newBuilder().setTimestampValue(timestamp).build();
+                } catch (DateTimeParseException e) {
+                    return null;
+                }
 
             // The serializer emits "documentReference"; "reference" is kept for
             // changelog rows written by older serializer versions.
             case "REFERENCE":
             case "DOCUMENTREFERENCE":
+                if (!value.isJsonPrimitive()) {
+                    return null;
+                }
 
                 String fullReferenceString = String.format(
                         "projects/%s/databases/%s/documents/%s",
@@ -175,12 +226,37 @@ public class FirestoreReconstructor {
             case "NULL":
                 return Value.newBuilder().setNullValue(com.google.protobuf.NullValue.NULL_VALUE).build();
             case "BINARY":
-                byte[] bytes = Base64.getDecoder().decode(value.getAsString());
+                if (!value.isJsonPrimitive()) {
+                    return null;
+                }
 
-                return Value.newBuilder().setBytesValue(com.google.protobuf.ByteString.copyFrom(bytes)).build();
+                try {
+                    byte[] bytes = Base64.getDecoder().decode(value.getAsString());
+
+                    return Value.newBuilder().setBytesValue(com.google.protobuf.ByteString.copyFrom(bytes)).build();
+                } catch (IllegalArgumentException e) {
+                    return null;
+                }
             default:
                 return null;
         }
+    }
+
+    private static Double buildCoordinate(JsonObject geopointValue, String name) {
+
+        JsonElement coordinate = geopointValue.get(name);
+
+        if (coordinate == null || !coordinate.isJsonObject()) {
+            return null;
+        }
+
+        JsonElement value = coordinate.getAsJsonObject().get("value");
+
+        if (value == null || !value.isJsonPrimitive() || !value.getAsJsonPrimitive().isNumber()) {
+            return null;
+        }
+
+        return value.getAsDouble();
     }
 
     private static List<Value> buildFirestoreList(JsonArray arr, String projectId, String databaseId) {
@@ -192,8 +268,9 @@ public class FirestoreReconstructor {
                 Value val = buildTaggedValue(taggedValue, projectId, databaseId);
 
                 if (val == null) {
-                    LOG.warn("Skipping array element: cannot reconstruct serialized type tag '{}'",
+                    LOG.warn("Nulling array element: cannot reconstruct serialized type tag '{}'",
                             taggedValue.get("type").getAsString());
+                    lst.add(UNRECONSTRUCTABLE_ELEMENT);
                     continue;
                 }
 
@@ -202,7 +279,8 @@ public class FirestoreReconstructor {
             }
 
             if (!el.isJsonObject()) {
-                LOG.warn("Skipping array element: expected a serialized value or a field map");
+                LOG.warn("Nulling array element: expected a serialized value or a field map");
+                lst.add(UNRECONSTRUCTABLE_ELEMENT);
                 continue;
             }
 

--- a/firestore-incremental-capture-pipeline/src/test/java/com/pipeline/FirestoreReconstructorTest.java
+++ b/firestore-incremental-capture-pipeline/src/test/java/com/pipeline/FirestoreReconstructorTest.java
@@ -17,10 +17,13 @@
 package com.pipeline;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.Base64;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
@@ -38,6 +41,13 @@ public class FirestoreReconstructorTest {
   private static Map<String, Value> build(String json) {
     JsonElement data = JsonParser.parseString(json);
     return FirestoreReconstructor.buildFirestoreMap(data, PROJECT_ID, DATABASE_ID);
+  }
+
+  private static List<Value> buildArrayElements(String elementsJson) {
+    Map<String, Value> fields = build(
+        "{\"items\":{\"type\":\"array\",\"value\":[" + elementsJson + "]}}");
+
+    return fields.get("items").getArrayValue().getValuesList();
   }
 
   @Test
@@ -83,5 +93,172 @@ public class FirestoreReconstructorTest {
     assertEquals(1, fields.size());
     assertTrue(fields.containsKey("name"));
     assertEquals("Ada", fields.get("name").getStringValue());
+  }
+
+  @Test
+  public void stringArrayElementsBecomeStringValues() {
+    List<Value> elements = buildArrayElements(
+        "{\"type\":\"string\",\"value\":\"a\"},{\"type\":\"string\",\"value\":\"b\"}");
+
+    assertEquals(2, elements.size());
+    assertEquals("a", elements.get(0).getStringValue());
+    assertEquals("b", elements.get(1).getStringValue());
+  }
+
+  @Test
+  public void numberArrayElementsBecomeDoubleValues() {
+    List<Value> elements = buildArrayElements(
+        "{\"type\":\"number\",\"value\":1},{\"type\":\"number\",\"value\":2.5}");
+
+    assertEquals(2, elements.size());
+    assertEquals(1.0, elements.get(0).getDoubleValue(), 0.0);
+    assertEquals(2.5, elements.get(1).getDoubleValue(), 0.0);
+  }
+
+  @Test
+  public void booleanArrayElementsBecomeBooleanValues() {
+    List<Value> elements = buildArrayElements(
+        "{\"type\":\"boolean\",\"value\":true},{\"type\":\"boolean\",\"value\":false}");
+
+    assertEquals(2, elements.size());
+    assertTrue(elements.get(0).getBooleanValue());
+    assertFalse(elements.get(1).getBooleanValue());
+  }
+
+  @Test
+  public void nullArrayElementBecomesANullValue() {
+    List<Value> elements = buildArrayElements("{\"type\":\"null\",\"value\":null}");
+
+    assertEquals(1, elements.size());
+    assertEquals(NullValue.NULL_VALUE, elements.get(0).getNullValue());
+    assertEquals(Value.ValueTypeCase.NULL_VALUE, elements.get(0).getValueTypeCase());
+  }
+
+  @Test
+  public void referenceArrayElementBecomesAFullyQualifiedReferenceValue() {
+    List<Value> elements = buildArrayElements(
+        "{\"type\":\"reference\",\"value\":\"users/abc\"},"
+            + "{\"type\":\"documentReference\",\"value\":\"users/def\"}");
+
+    assertEquals(2, elements.size());
+    assertEquals(
+        "projects/test-project/databases/test-db/documents/users/abc",
+        elements.get(0).getReferenceValue());
+    assertEquals(
+        "projects/test-project/databases/test-db/documents/users/def",
+        elements.get(1).getReferenceValue());
+  }
+
+  @Test
+  public void binaryArrayElementDecodesBase64IntoBytes() {
+    byte[] payload = "hello bytes".getBytes(StandardCharsets.UTF_8);
+    String base64 = Base64.getEncoder().encodeToString(payload);
+
+    List<Value> elements = buildArrayElements(
+        "{\"type\":\"binary\",\"value\":\"" + base64 + "\"}");
+
+    assertEquals(1, elements.size());
+    assertEquals(
+        com.google.protobuf.ByteString.copyFrom(payload),
+        elements.get(0).getBytesValue());
+  }
+
+  @Test
+  public void timestampArrayElementBecomesATimestampValue() {
+    Instant instant = Instant.parse("2026-01-02T03:04:05.000Z");
+
+    List<Value> elements = buildArrayElements(
+        "{\"type\":\"timestamp\",\"value\":\"2026-01-02T03:04:05.000Z\"}");
+
+    assertEquals(1, elements.size());
+    assertEquals(instant.getEpochSecond(), elements.get(0).getTimestampValue().getSeconds());
+    assertEquals(instant.getNano(), elements.get(0).getTimestampValue().getNanos());
+  }
+
+  @Test
+  public void geopointArrayElementBecomesAGeoPointValue() {
+    List<Value> elements = buildArrayElements(
+        "{\"type\":\"geopoint\",\"value\":{"
+            + "\"latitude\":{\"type\":\"number\",\"value\":52.379189},"
+            + "\"longitude\":{\"type\":\"number\",\"value\":4.899431}}}");
+
+    assertEquals(1, elements.size());
+    assertEquals(52.379189, elements.get(0).getGeoPointValue().getLatitude(), 0.0);
+    assertEquals(4.899431, elements.get(0).getGeoPointValue().getLongitude(), 0.0);
+  }
+
+  @Test
+  public void nestedArrayElementsAreReconstructed() {
+    List<Value> elements = buildArrayElements(
+        "{\"type\":\"array\",\"value\":[{\"type\":\"string\",\"value\":\"deep\"}]}");
+
+    assertEquals(1, elements.size());
+
+    List<Value> nested = elements.get(0).getArrayValue().getValuesList();
+
+    assertEquals(1, nested.size());
+    assertEquals("deep", nested.get(0).getStringValue());
+  }
+
+  @Test
+  public void mapArrayElementsAreReconstructedFromBareFieldMaps() {
+    List<Value> elements = buildArrayElements(
+        "{\"name\":{\"type\":\"string\",\"value\":\"Ada\"},"
+            + "\"age\":{\"type\":\"number\",\"value\":36}}");
+
+    assertEquals(1, elements.size());
+
+    Map<String, Value> fields = elements.get(0).getMapValue().getFieldsMap();
+
+    assertEquals(2, fields.size());
+    assertEquals("Ada", fields.get("name").getStringValue());
+    assertEquals(36.0, fields.get("age").getDoubleValue(), 0.0);
+  }
+
+  @Test
+  public void taggedAndMapElementsCoexistInOneArray() {
+    List<Value> elements = buildArrayElements(
+        "{\"type\":\"string\",\"value\":\"a\"},"
+            + "{\"name\":{\"type\":\"string\",\"value\":\"Ada\"}},"
+            + "{\"type\":\"null\",\"value\":null}");
+
+    assertEquals(3, elements.size());
+    assertEquals("a", elements.get(0).getStringValue());
+    assertEquals("Ada", elements.get(1).getMapValue().getFieldsMap().get("name").getStringValue());
+    assertEquals(Value.ValueTypeCase.NULL_VALUE, elements.get(2).getValueTypeCase());
+  }
+
+  @Test
+  public void mapElementWithTypeAndValueFieldsIsNotReadAsATaggedValue() {
+    List<Value> elements = buildArrayElements(
+        "{\"type\":{\"type\":\"string\",\"value\":\"invoice\"},"
+            + "\"value\":{\"type\":\"number\",\"value\":10}}");
+
+    assertEquals(1, elements.size());
+
+    Map<String, Value> fields = elements.get(0).getMapValue().getFieldsMap();
+
+    assertEquals("invoice", fields.get("type").getStringValue());
+    assertEquals(10.0, fields.get("value").getDoubleValue(), 0.0);
+  }
+
+  @Test
+  public void unknownTaggedArrayElementIsSkippedWithoutThrowing() {
+    List<Value> elements = buildArrayElements(
+        "{\"type\":\"vector\",\"value\":\"?\"},{\"type\":\"string\",\"value\":\"a\"}");
+
+    assertEquals(1, elements.size());
+    assertEquals("a", elements.get(0).getStringValue());
+  }
+
+  @Test
+  public void legacyNullArrayElementIsSkippedWithoutThrowing() {
+    // The original extension tagged a null array element with `typeof null`,
+    // which no reader can tell from a map. Those rows are unrecoverable.
+    List<Value> elements = buildArrayElements(
+        "{\"type\":\"object\",\"value\":null},{\"type\":\"string\",\"value\":\"a\"}");
+
+    assertEquals(1, elements.size());
+    assertEquals("a", elements.get(0).getStringValue());
   }
 }

--- a/firestore-incremental-capture-pipeline/src/test/java/com/pipeline/FirestoreReconstructorTest.java
+++ b/firestore-incremental-capture-pipeline/src/test/java/com/pipeline/FirestoreReconstructorTest.java
@@ -164,15 +164,15 @@ public class FirestoreReconstructorTest {
   }
 
   @Test
-  public void timestampArrayElementBecomesATimestampValue() {
-    Instant instant = Instant.parse("2026-01-02T03:04:05.000Z");
+  public void timestampArrayElementKeepsItsSecondsAndNanoseconds() {
+    Instant instant = Instant.parse("2026-01-02T03:04:05.123456789Z");
 
     List<Value> elements = buildArrayElements(
-        "{\"type\":\"timestamp\",\"value\":\"2026-01-02T03:04:05.000Z\"}");
+        "{\"type\":\"timestamp\",\"value\":\"2026-01-02T03:04:05.123456789Z\"}");
 
     assertEquals(1, elements.size());
     assertEquals(instant.getEpochSecond(), elements.get(0).getTimestampValue().getSeconds());
-    assertEquals(instant.getNano(), elements.get(0).getTimestampValue().getNanos());
+    assertEquals(123456789, elements.get(0).getTimestampValue().getNanos());
   }
 
   @Test
@@ -243,22 +243,152 @@ public class FirestoreReconstructorTest {
   }
 
   @Test
-  public void unknownTaggedArrayElementIsSkippedWithoutThrowing() {
+  public void unknownTaggedArrayElementBecomesANullPlaceholder() {
     List<Value> elements = buildArrayElements(
         "{\"type\":\"vector\",\"value\":\"?\"},{\"type\":\"string\",\"value\":\"a\"}");
 
-    assertEquals(1, elements.size());
-    assertEquals("a", elements.get(0).getStringValue());
+    assertEquals(2, elements.size());
+    assertEquals(Value.ValueTypeCase.NULL_VALUE, elements.get(0).getValueTypeCase());
+    assertEquals("a", elements.get(1).getStringValue());
   }
 
   @Test
-  public void legacyNullArrayElementIsSkippedWithoutThrowing() {
+  public void legacyNullArrayElementBecomesANullPlaceholder() {
     // The original extension tagged a null array element with `typeof null`,
-    // which no reader can tell from a map. Those rows are unrecoverable.
+    // so the value it carries is unreadable. The element was a null.
     List<Value> elements = buildArrayElements(
         "{\"type\":\"object\",\"value\":null},{\"type\":\"string\",\"value\":\"a\"}");
 
-    assertEquals(1, elements.size());
-    assertEquals("a", elements.get(0).getStringValue());
+    assertEquals(2, elements.size());
+    assertEquals(Value.ValueTypeCase.NULL_VALUE, elements.get(0).getValueTypeCase());
+    assertEquals("a", elements.get(1).getStringValue());
+  }
+
+  @Test
+  public void barePrimitiveArrayElementBecomesANullPlaceholder() {
+    List<Value> elements = buildArrayElements("\"loose\",{\"type\":\"string\",\"value\":\"a\"}");
+
+    assertEquals(2, elements.size());
+    assertEquals(Value.ValueTypeCase.NULL_VALUE, elements.get(0).getValueTypeCase());
+    assertEquals("a", elements.get(1).getStringValue());
+  }
+
+  @Test
+  public void emptyArrayKeepsTheFieldWithNoElements() {
+    Map<String, Value> fields = build("{\"items\":{\"type\":\"array\",\"value\":[]}}");
+
+    assertEquals(1, fields.size());
+    assertEquals(Value.ValueTypeCase.ARRAY_VALUE, fields.get("items").getValueTypeCase());
+    assertEquals(0, fields.get("items").getArrayValue().getValuesCount());
+  }
+
+  @Test
+  public void arrayTagWithoutAnArrayValueIsSkippedWithoutThrowing() {
+    Map<String, Value> fields = build(
+        "{\"items\":{\"type\":\"array\",\"value\":\"not an array\"},"
+            + "\"name\":{\"type\":\"string\",\"value\":\"Ada\"}}");
+
+    assertEquals(1, fields.size());
+    assertTrue(fields.containsKey("name"));
+  }
+
+  @Test
+  public void bigintBecomesAnIntegerValue() {
+    Map<String, Value> fields = build("{\"big\":{\"type\":\"bigint\",\"value\":\"9007199254740993\"}}");
+
+    assertEquals(1, fields.size());
+    assertEquals(9007199254740993L, fields.get("big").getIntegerValue());
+    assertEquals(Value.ValueTypeCase.INTEGER_VALUE, fields.get("big").getValueTypeCase());
+  }
+
+  @Test
+  public void bigintBeyondLongRangeBecomesANullPlaceholder() {
+    List<Value> elements = buildArrayElements(
+        "{\"type\":\"bigint\",\"value\":\"10\"},"
+            + "{\"type\":\"bigint\",\"value\":\"99999999999999999999999999\"}");
+
+    assertEquals(2, elements.size());
+    assertEquals(10L, elements.get(0).getIntegerValue());
+    assertEquals(Value.ValueTypeCase.NULL_VALUE, elements.get(1).getValueTypeCase());
+  }
+
+  @Test
+  public void nanSerializedAsANullNumberIsSkippedWithoutThrowing() {
+    // A NaN or Infinity double survives capture as a JSON null, which the
+    // reader cannot turn back into a double.
+    Map<String, Value> fields = build(
+        "{\"n\":{\"type\":\"number\",\"value\":null},"
+            + "\"name\":{\"type\":\"string\",\"value\":\"Ada\"}}");
+
+    assertEquals(1, fields.size());
+    assertTrue(fields.containsKey("name"));
+  }
+
+  @Test
+  public void scalarTagsWithoutAPrimitiveValueAreSkippedWithoutThrowing() {
+    Map<String, Value> fields = build(
+        "{\"s\":{\"type\":\"string\",\"value\":null},"
+            + "\"n\":{\"type\":\"number\",\"value\":{}},"
+            + "\"b\":{\"type\":\"boolean\",\"value\":null},"
+            + "\"t\":{\"type\":\"timestamp\",\"value\":null},"
+            + "\"r\":{\"type\":\"reference\",\"value\":null},"
+            + "\"bin\":{\"type\":\"binary\",\"value\":null},"
+            + "\"big\":{\"type\":\"bigint\",\"value\":null},"
+            + "\"name\":{\"type\":\"string\",\"value\":\"Ada\"}}");
+
+    assertEquals(1, fields.size());
+    assertTrue(fields.containsKey("name"));
+  }
+
+  @Test
+  public void scalarTagsWithoutAPrimitiveValueBecomeNullPlaceholders() {
+    List<Value> elements = buildArrayElements(
+        "{\"type\":\"string\",\"value\":null},"
+            + "{\"type\":\"number\",\"value\":null},"
+            + "{\"type\":\"boolean\",\"value\":null},"
+            + "{\"type\":\"timestamp\",\"value\":null},"
+            + "{\"type\":\"reference\",\"value\":null},"
+            + "{\"type\":\"binary\",\"value\":null}");
+
+    assertEquals(6, elements.size());
+    for (Value element : elements) {
+      assertEquals(Value.ValueTypeCase.NULL_VALUE, element.getValueTypeCase());
+    }
+  }
+
+  @Test
+  public void unparseableScalarValuesAreSkippedWithoutThrowing() {
+    Map<String, Value> fields = build(
+        "{\"t\":{\"type\":\"timestamp\",\"value\":\"yesterday\"},"
+            + "\"bin\":{\"type\":\"binary\",\"value\":\"not base64!\"},"
+            + "\"n\":{\"type\":\"number\",\"value\":\"abc\"},"
+            + "\"name\":{\"type\":\"string\",\"value\":\"Ada\"}}");
+
+    assertEquals(1, fields.size());
+    assertTrue(fields.containsKey("name"));
+  }
+
+  @Test
+  public void malformedGeopointIsSkippedWithoutThrowing() {
+    Map<String, Value> fields = build(
+        "{\"flat\":{\"type\":\"geopoint\",\"value\":{"
+            + "\"latitude\":52.379189,"
+            + "\"longitude\":{\"type\":\"number\",\"value\":4.899431}}},"
+            + "\"partial\":{\"type\":\"geopoint\",\"value\":{"
+            + "\"longitude\":{\"type\":\"number\",\"value\":4.899431}}},"
+            + "\"name\":{\"type\":\"string\",\"value\":\"Ada\"}}");
+
+    assertEquals(1, fields.size());
+    assertTrue(fields.containsKey("name"));
+  }
+
+  @Test
+  public void fieldValueThatIsNotATaggedValueIsSkippedWithoutThrowing() {
+    Map<String, Value> fields = build(
+        "{\"odd\":{\"type\":1,\"value\":\"x\"},"
+            + "\"name\":{\"type\":\"string\",\"value\":\"Ada\"}}");
+
+    assertEquals(1, fields.size());
+    assertTrue(fields.containsKey("name"));
   }
 }


### PR DESCRIPTION
`buildFirestoreList` wrapped every array element in a `MapValue`. Read that way, a tagged scalar element such as `{type: "string", value: "x"}` has no entries at all, so arrays of strings, numbers, booleans, references, bytes and nulls restored as arrays of empty maps - and the job reported success and logged nothing.

The tagged-value switch that `buildFirestoreMap` held inline is now a helper, and `buildFirestoreList` routes tagged elements through it. Map elements keep the bare field map path. The two are told apart by requiring a tagged element's `type` to be a JSON string: a user map's own `type` entry is itself a tagged object, so it cannot be mistaken for a tag. Nested arrays recurse.

Every branch of that helper now checks the shape of the value it was handed, and skips what it cannot read instead of throwing. This fixes a pre-existing job killer that the field path shares: Firestore accepts NaN and Infinity doubles, `JSON.stringify` writes them to the changelog as `{"type":"number","value":null}`, and `getAsDouble` threw out of a `SerializableFunction` inside a `BigQueryIO` read with no handler, so one such value failed the entire restore. The same held for a malformed timestamp, an invalid base64 payload and a malformed geopoint.

An element that cannot be reconstructed becomes a `NULL_VALUE` rather than being dropped, so the restored array keeps its length and its indices. For the legacy `{type: "object", value: null}` element, null is also what the user wrote.

`bigint` is added to the switch: the kit serializer emits a decimal string, which restores as an int64. A value beyond long range is nulled with a warning rather than throwing.

Back-compat: the older serializer tagged scalar elements identically, so existing changelog rows read fine. Rows the legacy serializer corrupted when it wrote them remain unrecoverable, and now cost only their own field or element.

Tests cover string, number, boolean, null, reference, binary, timestamp and geopoint elements, nested arrays, empty arrays, mixed tagged and map elements, bare map elements, bigint in and out of long range, unknown tags, and every newly guarded malformed shape.

Addresses the pipeline side of #1147. The extension serializer bugs in that issue remain open, and no live Dataflow restore has been run against this change.